### PR TITLE
Correct typo in oat.min.js script URL in usage documentation

### DIFF
--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -8,7 +8,7 @@ Include the CSS and JS files directly in your HTML:
 
 ```html
 <link rel="stylesheet" href="https://unpkg.com/@knadh/oat/oat.min.css">
-<script src="https://unpkg.com/@knadh/oatat.min.js" defer></script>
+<script src="https://unpkg.com/@knadh/oat/oat.min.js" defer></script>
 ```
 
 ----------


### PR DESCRIPTION
Thank you for this. Much appreciated. 

A simple typo made me spend a few minutes figuring out why my tabs weren't working.

Credit to Claude for figuring out, though. Not me.