### PR TITLE
feat: add breadcrumb navigation component

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ CSS_FILES = src/css/00-base.css \
             src/css/sidebar.css \
             src/css/skeleton.css \
             src/css/tooltip.css \
+            src/css/breadcrumb.css \
             src/css/utilities.css
 
 dist: css js size

--- a/docs/content/components/breadcrumb.md
+++ b/docs/content/components/breadcrumb.md
@@ -1,0 +1,20 @@
++++
+title = "Breadcrumb"
+weight = 35
+description = "Breadcrumb navigation using semantic HTML."
++++
+
+Use `<nav aria-label="breadcrumb">` with an `<ol>` list for breadcrumb navigation.
+Mark the current page with `aria-current="page"`.
+
+{% demo() %}
+```html
+<nav aria-label="breadcrumb">
+  <ol>
+    <li><a href="#">Home</a></li>
+    <li><a href="#">Components</a></li>
+    <li><a href="#" aria-current="page">Breadcrumb</a></li>
+  </ol>
+</nav>
+```
+{% end %}

--- a/src/css/breadcrumb.css
+++ b/src/css/breadcrumb.css
@@ -1,0 +1,45 @@
+@layer components {
+  nav[aria-label="breadcrumb"] {
+    font-size: var(--text-7);
+    color: var(--muted-foreground);
+
+    ol {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: var(--space-1);
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+
+    li {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--space-1);
+    }
+
+    /* Separator */
+    li+li::before {
+      content: "/";
+      color: var(--muted-foreground);
+    }
+
+    a {
+      color: var(--muted-foreground);
+      text-decoration: none;
+      transition: color var(--transition-fast);
+
+      &:hover {
+        color: var(--foreground);
+      }
+    }
+
+    /* Current page - not a link */
+    [aria-current="page"] {
+      color: var(--foreground);
+      font-weight: var(--font-medium);
+      pointer-events: none;
+    }
+  }
+}


### PR DESCRIPTION
### What was done
- **Added** [src/css/breadcrumb.css](cci:7://file:///c:/Users/Admin/Desktop/oat/src/css/breadcrumb.css:0:0-0:0) -> Semantic breadcrumb styling using `nav[aria-label="breadcrumb"]` with ordered list structure. Separators are rendered via CSS `::before` pseudo-elements, requiring no extra markup.
- **Updated** [Makefile](cci:7://file:///c:/Users/Admin/Desktop/oat/Makefile:0:0-0:0) -> Registered the new CSS file in the build pipeline.
- **Added** [docs/content/components/breadcrumb.md](cci:7://file:///c:/Users/Admin/Desktop/oat/docs/content/components/breadcrumb.md:0:0-0:0) -> Documentation page with a live demo following the existing component page format.

### Design decisions
- **No JavaScript needed** -> Breadcrumbs are purely navigational; links work natively.
- **Semantic HTML** -> Uses `<nav>`, `<ol>`, `<li>`, `<a>` with `aria-label="breadcrumb"` and `aria-current="page"` for accessibility.
- **Theme-compatible** -> Automatically adapts to light and dark modes via existing `--foreground` and `--muted-foreground` variables. No separate dark mode overrides required.
- **Minimal footprint** -> ~903 bytes unminified CSS, well within the project's ultra-lightweight budget.

### Testings made
- Verified breadcrumb items render with correct `/` separators
- Confirmed hover state transitions on links
- Validated current page item appears visually distinct and non-clickable
- Tested in both light and dark themes
- Build succeeds via `make dist`

### screenshots

**Dark mode - `home` tab was toggled**
<img width="1789" height="753" alt="image" src="https://github.com/user-attachments/assets/bf543538-199d-4c75-aa18-03ecba6907dd" />

**Light mode - `Components` tab was toggled**
<img width="1846" height="747" alt="image" src="https://github.com/user-attachments/assets/3a4a68cc-9050-4187-9397-cdf7497a5db8" />

### **Fixes #11**