### PR TITLE
fix: dark mode style fixes for scrollbars and chevron icon colors

### DIFF
--- a/src/css/01-theme.css
+++ b/src/css/01-theme.css
@@ -76,7 +76,7 @@
   }
 
   [data-theme="dark"] {
-      color-scheme: dark;
+    color-scheme: dark;
     --background: #09090b;
     --foreground: #fafafa;
     --card: #18181b;

--- a/src/css/accordion.css
+++ b/src/css/accordion.css
@@ -41,12 +41,13 @@
 
     &::after {
       content: "";
-      width: 1rem;
-      height: 1rem;
+      width: 1em;
+      height: 1em;
+      flex-shrink: 0;
       background-color: currentColor;
-      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
-      background-size: contain;
-      background-repeat: no-repeat;
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+      mask-size: contain;
+      mask-repeat: no-repeat;
       transition: transform var(--transition-fast);
     }
 


### PR DESCRIPTION
thanks for making oat 🙏🏻 

This PR addresses two visual issues in dark mode:
1. Native scrollbar styling - Added color-scheme: dark to the dark theme CSS, which instructs browsers to render native UI elements (scrollbars, form controls) in dark mode to match the theme.
2. Accordion chevron visibility - Fixed the accordion chevron icon to properly adapt to theme colors by using background-color: currentColor with mask-image instead of background-image, allowing the icon to inherit the foreground color in both light and dark themes.
Changes:
- src/css/01-theme.css - Added color-scheme: dark property
- src/css/accordion.css - Switched from background-image to background-color: currentColor + mask-image for the chevron icon

<img width="484" height="766" alt="image" src="https://github.com/user-attachments/assets/6771b181-ffd3-467b-ac40-65febca27d1c" />
<img width="906" height="766" alt="image" src="https://github.com/user-attachments/assets/69bf9020-810b-486e-87bd-52a8d7feff53" />
