### PR TITLE
fix(docs): prevent FOUC in dark mode

### DIFF
--- a/docs/static/main.js
+++ b/docs/static/main.js
@@ -23,10 +23,6 @@ document.addEventListener('DOMContentLoaded', () => {
     // Move the original Zola syntax-highlighted <pre> into the Code tab.
     demo.querySelector(':scope > ot-tabs > [role="tabpanel"]:last-child').appendChild(pre);
   });
-
-  // Set theme based on saved preference or system setting.
-  var t = localStorage.getItem('theme') || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-  document.documentElement.setAttribute('data-theme', t);
 });
 
 

--- a/docs/templates/base.html
+++ b/docs/templates/base.html
@@ -7,18 +7,16 @@
   <title>{% block title %}{{ config.title }}{% endblock %}</title>
 
   <meta property="og:image" content="https://oat.ink/thumb.png">
-  <script>
-    // Prevent FOUC - apply theme before rendering
-    (function() {
-      var theme = localStorage.getItem('theme');
-      if (!theme) {
-        theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-      }
-      document.documentElement.setAttribute('data-theme', theme);
-    })();
-  </script>
   <link rel="stylesheet" href="/oat.min.css">
   <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+
+  <script>
+    // Prevent FOUC - apply theme before rendering.
+    (function() {
+      var t = localStorage.getItem('theme') || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      document.documentElement.setAttribute('data-theme', t);
+    })();
+  </script>
   <script src="/oat.min.js" defer></script>
   <script src="/main.js"></script>
   <style>


### PR DESCRIPTION
Add inline synchronous script in <head> to apply theme before rendering. Previously, theme was applied on DOMContentLoaded causing flash of light mode before dark mode loaded.