### PR TITLE
Add copy button to docs code blocks

### DIFF
--- a/docs/static/main.js
+++ b/docs/static/main.js
@@ -1,10 +1,10 @@
-document.addEventListener('DOMContentLoaded', () => {
+function setupDemos() {
   document.querySelectorAll('.ot-demo').forEach(demo => {
     const pre = demo.querySelector('pre');
     if (!pre) return;
 
     const code = pre.querySelector('code');
-    const rawHTML = code.textContent;
+    const rawHTML = code ? code.textContent : pre.textContent;
 
     // Create tabbed interface.
     demo.innerHTML = `
@@ -23,8 +23,80 @@ document.addEventListener('DOMContentLoaded', () => {
     // Move the original Zola syntax-highlighted <pre> into the Code tab.
     demo.querySelector(':scope > ot-tabs > [role="tabpanel"]:last-child').appendChild(pre);
   });
-});
+}
 
+function setupCodeCopyButtons() {
+  if (!navigator.clipboard || !navigator.clipboard.writeText) {
+    return;
+  }
+
+  const copyIcon = `
+    <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <rect x="4" y="3" width="9" height="9" rx="2" fill="none" stroke="currentColor" stroke-width="1.6" />
+      <rect x="8" y="7" width="9" height="9" rx="2" fill="none" stroke="currentColor" stroke-width="1.6" />
+    </svg>
+  `;
+
+  const checkIcon = `
+    <svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <polyline points="4 12 10 18 20 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    </svg>
+  `;
+
+  document.querySelectorAll('pre').forEach(pre => {
+    // Avoid re-processing the same block.
+    if (pre.dataset.copyButtonAttached === 'true') {
+      return;
+    }
+    pre.dataset.copyButtonAttached = 'true';
+
+    const parent = pre.parentNode;
+    if (!parent) {
+      return;
+    }
+
+    // Wrap <pre> in a container so we can position the button.
+    const wrapper = document.createElement('div');
+    wrapper.className = 'code-block';
+    parent.insertBefore(wrapper, pre);
+    wrapper.appendChild(pre);
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'copy-button';
+    button.setAttribute('aria-label', 'Copy code');
+    button.setAttribute('title', 'Copy');
+    button.innerHTML = copyIcon;
+
+    button.addEventListener('click', () => {
+      const codeEl = pre.querySelector('code');
+      const text = codeEl ? codeEl.textContent : pre.textContent || '';
+
+      navigator.clipboard.writeText(text)
+        .then(() => {
+          button.innerHTML = checkIcon;
+          button.setAttribute('aria-label', 'Copied');
+          button.disabled = true;
+
+          window.setTimeout(() => {
+            button.innerHTML = copyIcon;
+            button.setAttribute('aria-label', 'Copy code');
+            button.disabled = false;
+          }, 1200);
+        })
+        .catch(() => {
+          // On failure, leave the button as-is.
+        });
+    });
+
+    wrapper.appendChild(button);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  setupDemos();
+  setupCodeCopyButtons();
+});
 
 function toggleTheme() {
   var theme = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';

--- a/docs/templates/base.html
+++ b/docs/templates/base.html
@@ -178,6 +178,46 @@
       }
     }
 
+    .code-block {
+      position: relative;
+    }
+
+    .code-block pre {
+      margin-block-end: 0;
+    }
+
+    .code-block .copy-button {
+      position: absolute;
+      top: var(--space-3);
+      right: var(--space-3);
+      z-index: 1;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0;
+      background: transparent;
+      border: none;
+      box-shadow: none;
+      color: var(--muted-foreground);
+      opacity: 0;
+      transform: translateY(-2px);
+      pointer-events: none;
+      transition:
+        opacity var(--transition-fast),
+        transform var(--transition-fast);
+    }
+
+    .code-block .copy-button svg {
+      display: block;
+    }
+
+    .code-block:hover .copy-button,
+    .code-block:focus-within .copy-button {
+      opacity: 1;
+      transform: translateY(0);
+      pointer-events: auto;
+    }
+
     .section-permalink {
       display: block;
       margin-top: var(--space-4);


### PR DESCRIPTION


https://github.com/user-attachments/assets/35911495-acb6-4420-8ce5-699f165570a2




## Summary
- Add a minimal copy-to-clipboard button to all markdown-rendered code blocks in the docs.
- Show the icon-only button on hover/focus of the code block, with a checkmark state after a successful copy.

## Implementation details
- Wrap each  pre in a `.code-block` container and inject a minimal overlapping-squares copy icon button via `docs/static/main.js`.
- Add CSS in `docs/templates/base.html` to position the button in the top-right corner of the code block and only reveal it on hover/focus.

PS: Assisted via [Cursor](https://cursor.com/).

---

Fixes https://github.com/knadh/oat/issues/28
