### PR TITLE
Fixes theme toggle label and icon for current theme

### DIFF
--- a/docs/static/main.js
+++ b/docs/static/main.js
@@ -23,11 +23,25 @@ document.addEventListener('DOMContentLoaded', () => {
     // Move the original Zola syntax-highlighted <pre> into the Code tab.
     demo.querySelector(':scope > ot-tabs > [role="tabpanel"]:last-child').appendChild(pre);
   });
+
+  updateThemeToggle(document.documentElement.getAttribute('data-theme') || 'light');
 });
 
+const THEME_ICONS = {
+  light: '<circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>',
+  dark: '<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>'
+};
 
 function toggleTheme() {
   var theme = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
   document.documentElement.setAttribute('data-theme', theme);
   localStorage.setItem('theme', theme);
+  updateThemeToggle(theme);
+}
+
+function updateThemeToggle(theme) {
+  var btn = document.getElementById('theme-toggle');
+  if (!btn) return;
+  btn.querySelector('.theme-icon').innerHTML = THEME_ICONS[theme];
+  btn.querySelector('.theme-label').textContent = theme === 'dark' ? 'Dark mode' : 'Light mode';
 }

--- a/docs/templates/base.html
+++ b/docs/templates/base.html
@@ -256,15 +256,9 @@
       </ul>
     </nav>
     <footer>
-      <button class="outline small" onclick="toggleTheme()">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <circle cx="12" cy="12" r="5"/>
-          <line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/>
-          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
-          <line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/>
-          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
-        </svg>
-        Dark mode
+      <button id="theme-toggle" class="outline small" onclick="toggleTheme()">
+        <svg class="theme-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"></svg>
+        <span class="theme-label"></span>
       </button>
     </footer>
   </aside>


### PR DESCRIPTION
## Summary

[x] Fixes the docs theme toggle so the icon and label match the active theme instead of staying static.

## Test Plan

1. Load docs site in light mode and verify button shows light state.
2. Switch to dark mode and verify button updates immediately.
3. Refresh page and verify persisted theme still shows correct label/icon.

## Screenshots

### Before
<img width="1703" height="1065" alt="Screenshot 2026-02-13 at 11 57 48 PM" src="https://github.com/user-attachments/assets/efbff882-ecf4-473e-a564-1c45ceb6ae8e" />
<img width="1703" height="1065" alt="Screenshot 2026-02-13 at 11 57 58 PM" src="https://github.com/user-attachments/assets/2f9e0efd-cd20-4ef9-969b-571b41bfcb5d" />

### Fixes
<img width="1703" height="1065" alt="Screenshot 2026-02-13 at 11 58 14 PM" src="https://github.com/user-attachments/assets/c4860671-1c84-4c0b-95ee-00be398abdc8" />
<img width="1703" height="1065" alt="Screenshot 2026-02-13 at 11 58 23 PM" src="https://github.com/user-attachments/assets/e60c2489-4ab0-42c2-a719-c48fa9014bad" />


### Fixes #29 