### PR TITLE
Fix typo in toast button example

### DIFF
--- a/docs/content/components/toast.md
+++ b/docs/content/components/toast.md
@@ -11,7 +11,7 @@ Show toast notifications with `ot.toast(message, options?)`.
 <button onclick="ot.toast('Action completed successfully', 'All good', { variant: 'success' })">Success</button>
 <button onclick="ot.toast('Something went wrong', 'Oops', { variant: 'danger', placement: 'top-left' })" data-variant="danger">Danger</button>
 <button onclick="ot.toast('Please review this warning', 'Warning', { variant: 'warning', placement: 'bottom-right' })" class="outline">Warning</button>
-<button onclick="ot.toast('New notification', 'For your attenton', { placement: 'top-center' })">Info</button>
+<button onclick="ot.toast('New notification', 'For your attention', { placement: 'top-center' })">Info</button>
 ```
 {% end %}
 


### PR DESCRIPTION
Corrected a typo in the toast button example.