### PR TITLE
 docs: clarify ot.toast() parameter order (message, title)

### DIFF
--- a/docs/content/components/toast.md
+++ b/docs/content/components/toast.md
@@ -4,7 +4,7 @@ weight = 160
 description = "Notification toasts with placement and stacking."
 +++
 
-Show toast notifications with `ot.toast(message, options?)`.
+Show toast notifications with `ot.toast(message, title?, options?)`.
 
 {% demo() %}
 ```html

--- a/src/js/toast.js
+++ b/src/js/toast.js
@@ -3,9 +3,9 @@
  *
  * Usage:
  *   ot.toast('Saved!')
- *   ot.toast('Saved!', 'Your changes have been saved.')
- *   ot.toast('Success', 'Operation completed.', { variant: 'success' })
- *   ot.toast('Error', 'Something went wrong.', { variant: 'danger', placement: 'bottom-center' })
+ *   ot.toast('Action completed successfully', 'All good')
+ *   ot.toast('Operation completed.', 'Success', { variant: 'success' })
+ *   ot.toast('Something went wrong.', 'Error', { variant: 'danger', placement: 'bottom-center' })
  *
  *   // Custom markup
  *   ot.toastEl(element)


### PR DESCRIPTION
## Description

The ot.toast() API uses (message, title?, options?) parameter order — message first, optional title second. This is an intentional design choice: the most common use case is a simple single-message toast like ot.toast('Saved!'), where the required argument (message) comes first and the optional one (title) comes second.

Ideally, a notification API would take title as the first parameter and message as the second — matching how notifications are visually read (heading first, body second) and aligning with conventions in libraries like `Sonner`, `react-hot-toast` etc... However, since the existing API is already with (message, title) order and changing it would be a breaking change, we keep the parameter order as-is.

## Changes

1.   Updated the JSDoc usage examples in src/js/toast.js to make the (message, title) order unambiguous:
      Before: 
      ```js
      ot.toast('Saved!', 'Your changes have been saved.')  // first arg reads like a title, causing confusion
      ```
      
      After: 
      ```js
      ot.toast('Action completed successfully', 'All good')  // first arg is clearly the longer message, second is the short title
      ```

2. Updated docs/content/components/toast.md:

    API signature clarified to ot.toast(message, title?, options?)


