### PR TITLE
Fix typo in download instructions for CSS and JS files

### DIFF
--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -32,7 +32,7 @@ Or import individual files from `@knadh/oat/css` and `@knadh/oat/js`.
 
 ### Download
 
-Download the the CSS and JS files:
+Download the CSS and JS files:
 
 ```shell
 wget https://raw.githubusercontent.com/knadh/oat/refs/heads/gh-pages/oat.min.css


### PR DESCRIPTION
removed two times "the" in download instructions for CSS and JS files in usage.md file.