### PR TITLE
feat(forms): add vertical and multi-thumb range patterns

### DIFF
--- a/docs/content/components/form.md
+++ b/docs/content/components/form.md
@@ -76,6 +76,11 @@ Form elements are styled automatically. Wrap inputs in `<label>` for proper asso
     <input type="range" min="0" max="100" value="50" />
   </label>
 
+  <label data-field>
+   Vertical volume
+   <input type="range" min="0" max="100" value="40" vertical />
+  </label>
+
   <button type="submit">Submit</button>
 </form>
 ```
@@ -102,6 +107,19 @@ Use `.group` on a `<fieldset>` to combine inputs with buttons or labels.
   <input type="text" placeholder="Search" />
   <button>Go</button>
 </fieldset>
+```
+{% end %}
+
+### Multi-thumb slider
+
+Use the `range-group` attribute on a wrapping element to stack multiple input[type="range"] elements and create a multi-thumb slider.
+
+{% demo() %}
+```html
+<label range-group>
+  <input type="range" min="0" max="100" value="20">
+  <input type="range" min="0" max="100" value="80">
+</label>
 ```
 {% end %}
 

--- a/src/css/form.css
+++ b/src/css/form.css
@@ -172,6 +172,12 @@
       }
     }
 
+   input[type=range][vertical] {
+    writing-mode: bt-lr;
+    width: var(--bar-height);
+    height: 8rem;
+   }
+
     &::-moz-range-thumb {
       width: 1.25rem;
       height: 1.25rem;
@@ -234,6 +240,31 @@
       border-radius: var(--radius-medium) 0 0 var(--radius-medium);
     }
   }
+
+   /* -----------------------------------
+     Multi-thumb range pattern
+  ------------------------------------ */
+  .range-group {
+    position: relative;
+    display:block;
+    height: var(--bar-height);
+  }
+
+  .range-group input[type=range]{
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: transparent;
+  }
+
+  .range-group input[type=range]::-webkit-slider-thumb{
+    pointer-events: auto;
+  }
+
+  .range-group input[type=range]::-moz-range-thumb{
+    pointer-events: auto;
+  }
+
 
   [data-field] {
     margin-block-end: var(--space-4);


### PR DESCRIPTION
**Adds**:
- vertical attribute for vertical sliders
- range-group pattern for multi-thumb sliders
- Related issue #55 
Both implementations are CSS-only and keep input[type="range"] fully native.