### PR TITLE
chore: move .unstyled utility inside @layer utilities

### DIFF
--- a/src/css/utilities.css
+++ b/src/css/utilities.css
@@ -53,12 +53,12 @@
   .p-4 { padding: var(--space-4); }
 
   .w-100 { width: 100%; }
-}
 
-ul, ol {
-  &.unstyled {
-    list-style: none;
-    padding-inline-start: 0;
-    margin-inline-start: 0;
+  ul, ol {
+    &.unstyled {
+      list-style: none;
+      padding-inline-start: 0;
+      margin-inline-start: 0;
+    }
   }
 }


### PR DESCRIPTION
## Description

The `.unstyled` utility class for lists was defined outside any `@layer`, making it unlayered CSS. In CSS Cascade Layers, unlayered styles have higher priority than all layered styles, so

Breaks the layer contract —  `@layer` theme, base, components, animations, utilities to give consumers predictable specificity control. Having `.unstyled` outside this system means it cannot be overridden by consumer layers without !important.

Inconsistent with the codebase — Every other utility class (`.flex`, `.hstack`, `.sr-only`, `.w-100`, etc.) is inside `@layer` utilities. This appears to be an oversight where `.unstyled` was added after the closing brace.

I am unable to identify any intentional behaviour I would be happy to know if there is any reason.