### PR TITLE
fix: add missing --faint-foreground variable and implement .text-lighter

### DIFF
--- a/src/css/01-theme.css
+++ b/src/css/01-theme.css
@@ -12,6 +12,7 @@
     --muted: #f4f4f5;
     --muted-foreground: #71717a;
     --faint: #fafafa;
+    --faint-foreground: #a1a1aa;
     --accent: #f4f4f5;
     --danger: #df514c;
     --danger-foreground: #fafafa;
@@ -88,6 +89,7 @@
     --muted: #27272a;
     --muted-foreground: #a1a1aa;
     --faint: #1e1e21;
+    --faint-foreground: #71717a;
     --accent: #27272a;
     --danger-foreground: #fafafa;
     --success-foreground: #fafafa;

--- a/src/css/utilities.css
+++ b/src/css/utilities.css
@@ -19,7 +19,7 @@
   .text-center { text-align: center; }
   .text-right { text-align: end; }
   .text-light { color: var(--muted-foreground); }
-  .text-lighter { color: var(--muted-foreground); }
+  .text-lighter { color: var(--faint-foreground); }
 
   .flex { display: flex; }
   .flex-col { flex-direction: column; }


### PR DESCRIPTION
### Description

The `.text-lighter` utility class was defined but functionally identical to `.text-light` — both used `var(--muted-foreground)`. This was because the `--faint-foreground` CSS variable was documented in [docs/content/customizing.md](https://github.com/knadh/oat/blob/master/docs/content/customizing.md) but never actually implemented in the theme CSS.

Documentation shows:
```css
/* Muted (lighter) text colour */
--muted-foreground: rgb(113 113 122);
 
/* Subtler than muted text color */
--faint-foreground: rgb(161 161 170);
```
`01-theme.css` was missing --faint-foreground entirely. so,
1. Added `--faint-foreground` to theme variables (src/css/01-theme.css)
2. Updated `.text-lighter` to use the new variable 

## Color Progression

### Light Mode

| Token                | Color     | Description                          |
|----------------------|-----------|--------------------------------------|
| `--foreground`        | `#09090b` | Darkest – Main text                  |
| `--muted-foreground`  | `#71717a` | Lighter – `.text-light`              |
| `--faint-foreground`  | `#a1a1aa` | Even lighter – `.text-lighter`       |

### Dark Mode (Inverted)

| Token                | Color     | Description                          |
|----------------------|-----------|--------------------------------------|
| `--foreground`        | `#fafafa` | Lightest – Main text                 |
| `--muted-foreground`  | `#a1a1aa` | Darker – `.text-light`               |
| `--faint-foreground`  | `#71717a` | Even darker – `.text-lighter`        |

