### PR TITLE
 fix: add `resize` event to dropdown for proper repositioning

### DIFF
--- a/src/js/dropdown.js
+++ b/src/js/dropdown.js
@@ -39,10 +39,11 @@ class OtDropdown extends OtBase {
     if (e.newState === 'open') {
       this.#position();
       window.addEventListener('scroll', this.#position, true);
+      window.addEventListener('resize', this.#position);
       this.$('[role="menuitem"]')?.focus();
       this.#trigger.ariaExpanded = 'true';
     } else {
-      window.removeEventListener('scroll', this.#position, true);
+      this.cleanup();
       this.#trigger.ariaExpanded = 'false';
       this.#trigger.focus();
     }
@@ -68,6 +69,7 @@ class OtDropdown extends OtBase {
 
   cleanup() {
     window.removeEventListener('scroll', this.#position, true);
+    window.removeEventListener('resize', this.#position);
   }
 }
 


### PR DESCRIPTION
### Description

The dropdown component repositions itself on scroll but not on window resize. This causes the dropdown to become misaligned from its trigger button when user resizes the browser window / rotates device (mobile).

major UI library handles both scroll and resize events for dropdown/popover repositioning. Eg: [Popper.js ](https://popper.js.org/docs/v2/modifiers/event-listeners/) & [Material-UI (MUI)](https://github.com/mui/material-ui/blob/d0c928c82e3fc8f284a2f7fd1b9acbf717c5a64e/packages/material-ui/src/Popover/Popover.js#L369)
