### PR TITLE
Fix: Remove mobile tap highlight

### DIFF
--- a/src/css/00-base.css
+++ b/src/css/00-base.css
@@ -175,3 +175,7 @@
     cursor: not-allowed;
   }
 }
+
+* {
+  -webkit-tap-highlight-color: transparent;
+}


### PR DESCRIPTION
Added CSS to remove mobile tap highlight for better UX on touch devices.

Fixes #62
