### PR TITLE
fix: ensure that commandfor polyfill only affects button elements

### DIFF
--- a/src/js/base.js
+++ b/src/js/base.js
@@ -89,7 +89,7 @@ if (typeof window !== 'undefined') {
 // Polyfill for command/commandfor (Safari)
 if (!('commandForElement' in HTMLButtonElement.prototype)) {
   document.addEventListener('click', e => {
-    const btn = e.target.closest('[commandfor]');
+    const btn = e.target.closest('button[commandfor]');
     if (!btn) return;
 
     const target = document.getElementById(btn.getAttribute('commandfor'));


### PR DESCRIPTION
This fixes the incompatible behavior in the polyfill. I ran into it myself when I accidentally added `commandfor` to an anchor tag. The polyfill worked, but it failed on actual browsers because anchor tags don’t support that attribute.