### PR TITLE
Fix null safety in toastEl and dropdown cleanup on DOM removal

### DIFF
--- a/src/js/dropdown.js
+++ b/src/js/dropdown.js
@@ -70,6 +70,8 @@ class OtDropdown extends OtBase {
   cleanup() {
     window.removeEventListener('scroll', this.#position, true);
     window.removeEventListener('resize', this.#position);
+    try { this.#menu?.hidePopover(); } catch {}
+    if (this.#trigger) this.#trigger.ariaExpanded = 'false';
   }
 }
 

--- a/src/js/toast.js
+++ b/src/js/toast.js
@@ -96,13 +96,19 @@ ot.toast = function (message, title, options = {}) {
 ot.toastEl = function (el, options = {}) {
   let toast;
 
-  if (el instanceof HTMLTemplateElement) {
-    toast = el.content.firstElementChild.cloneNode(true);
-  } else if (typeof el === 'string') {
-    toast = document.querySelector(el).cloneNode(true);
-  } else {
-    toast = el.cloneNode(true);
+  let src = el;
+  if (typeof el === 'string') {
+    src = document.querySelector(el);
+    if (!src) return;
   }
+
+  if (src instanceof HTMLTemplateElement) {
+    toast = src.content.firstElementChild?.cloneNode(true);
+  } else {
+    toast = src.cloneNode(true);
+  }
+
+  if (!toast) return;
 
   toast.removeAttribute('id');
 


### PR DESCRIPTION
## Summary
- **toast.js**: Guard against null querySelector results and empty template elements in ot.toastEl() to prevent uncaught TypeError
- **dropdown.js**: Hide popover and reset aria-expanded in cleanup() to prevent stale UI when element is removed while open (SPA scenarios)

## Details

### ot.toastEl() null safety
When calling ot.toastEl with a selector that matches no element, document.querySelector returns null and .cloneNode throws an uncaught TypeError. Similarly, passing an empty template causes el.content.firstElementChild to be null. The fix adds null guards consistent with how other oat components handle missing elements.

### Dropdown cleanup on DOM removal
When an ot-dropdown is removed from the DOM while its popover is open (common in SPA frameworks), disconnectedCallback calls cleanup() which removes scroll/resize listeners but does not hide the popover or reset aria-expanded. This leaves a stale popover visible. The fix hides the popover and resets ARIA state during cleanup.

## Test plan
- Call ot.toastEl with a non-matching selector - should no longer throw
- Call ot.toastEl with an empty template - should no longer throw
- Open a dropdown, remove the element from DOM - popover should disappear and ARIA state should reset