### PR TITLE
feat(nav): highlight active component in sidebar navigation

### DIFF
--- a/docs/static/main.js
+++ b/docs/static/main.js
@@ -103,6 +103,61 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     }
   });
+
+  function initNavHighlight() {
+    const linkMap = {};
+    document.querySelectorAll('aside nav a').forEach(a => {
+      const hash = new URL(a.href, location.origin).hash;
+      if (hash) {
+        linkMap[hash] = a;
+      }
+    });
+
+    const sections = Array.from(document.querySelectorAll('[id]')).filter(
+      el => linkMap['#' + el.id]
+    );
+
+    if (!sections.length) {
+      return;
+    };
+
+    let currentActiveEl = null;
+
+    const observer = new IntersectionObserver((components) => {
+      components.forEach(component => {
+        const activeEl = linkMap['#' + component.target.id];
+        if (!activeEl) {
+          return;
+        }
+        if (component.isIntersecting) {
+          if (currentActiveEl) {
+            currentActiveEl.classList.remove('active');
+          }
+          currentActiveEl = activeEl;
+          activeEl.classList.add('active');
+        }
+      });
+    }, {
+      rootMargin: '-10% 0px -80% 0px',
+      threshold: 0
+    });
+
+    sections.forEach(s => observer.observe(s));
+
+    function syncFromHash() {
+      const activeEl = linkMap[location.hash];
+      if (activeEl) {
+        if (currentActiveEl) {
+          currentActiveEl.classList.remove('active');
+        }
+        currentActiveEl = activeEl;
+        activeEl.classList.add('active');
+      }
+    }
+    syncFromHash();
+    window.addEventListener('hashchange', syncFromHash);
+  }
+  initNavHighlight();
 });
 
 

--- a/src/css/sidebar.css
+++ b/src/css/sidebar.css
@@ -80,6 +80,10 @@
           &:is(:hover, [aria-current]) {
             background-color: var(--accent);
           }
+
+          &.active {
+            font-weight: var(--font-medium);
+          }
         }
 
         details {


### PR DESCRIPTION
fixes: #99 

Highlights the currently active component in the sidebar navigation based on the URL, making it easier to identify the active section while browsing components.

Ref:
<img width="1920" height="1009" alt="image" src="https://github.com/user-attachments/assets/58b082aa-49ee-4053-8529-f6612975f28a" />
