### PR TITLE
fix: dynamically calculate toast cleanup timeout from CSS transition …

### DIFF
--- a/src/js/toast.js
+++ b/src/js/toast.js
@@ -126,8 +126,25 @@ function removeToast(toast, container) {
     }
   };
 
+  // Calculate transition duration from computed styles to match CSS
+  // Falls back to 200ms if calculation fails (matches CSS transition duration)
+  const getTransitionDuration = () => {
+    // Force reflow to ensure data-exiting styles are applied
+    void toast.offsetHeight;
+    const style = window.getComputedStyle(toast);
+    const transitionDuration = style.transitionDuration;
+    if (transitionDuration && transitionDuration !== '0s') {
+      // Parse duration (e.g., "0.2s" -> 200ms)
+      // Handle multiple durations by taking the maximum
+      const durations = transitionDuration.split(',').map(d => parseFloat(d.trim()) * 1000);
+      const maxDuration = Math.max(...durations);
+      return Math.max(maxDuration, 200); // Ensure minimum 200ms
+    }
+    return 200; // Fallback to CSS transition duration
+  };
+
   toast.addEventListener('transitionend', cleanup, { once: true });
-  setTimeout(cleanup, 200);
+  setTimeout(cleanup, getTransitionDuration());
 }
 
 // Clear all toasts.


### PR DESCRIPTION
Fixes #89 

Replace hardcoded 200ms timeout with dynamic calculation that reads the transition duration from computed styles. This ensures the timeout always matches the CSS transition duration, even if it changes.

- Calculate duration after setting data-exiting attribute
- Handle multiple transition durations by taking the maximum
- Fallback to 200ms if calculation fails
- Force reflow to ensure styles are applied before reading