### PR TITLE
Make border on focused form elements more visible

### DIFF
--- a/src/css/form.css
+++ b/src/css/form.css
@@ -32,6 +32,7 @@
       outline: none;
       border-color: var(--ring);
       box-shadow: 0 0 0 2px rgb(from var(--ring) r g b / 0.2);
+      z-index: 1;
     }
 
     &:disabled {
@@ -206,7 +207,10 @@
     & > :is(input, textarea, select) {
       flex: 1;
       margin-block-start: 0;
-      border-inline-end: 0;
+     
+      &:not(:focus) {
+        border-inline-end-color: transparent;
+      }
     }
 
     & > :is(input, textarea, select, button) {


### PR DESCRIPTION
Add z-index to focused form elements to make the focus shadow appear above other visually close elements.
Made the right part of the border appear when focused, so that we get complete focus styles

This mainly affects input groups, but it also comes into play if the input field is placed close to other elements in other contexts.

Before:
<img width="1327" height="142" alt="image" src="https://github.com/user-attachments/assets/ffad1404-6037-4c03-8986-b37b30b493f1" />

After:
<img width="1338" height="155" alt="image" src="https://github.com/user-attachments/assets/c154293f-523f-4c42-b990-bd2a84e480a9" />

This does make the input field grow by 1px when focused; however, I don't see an obvious solution, but I might be missing something simple.