### PR TITLE
feat: add carousel component and enhance datepicker range APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 dist
+node_modules
+.tools

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ CSS_FILES = src/css/00-base.css \
             src/css/animations.css \
             src/css/button.css \
             src/css/form.css \
+            src/css/datepicker.css \
+            src/css/carousel.css \
             src/css/table.css \
             src/css/progress.css \
             src/css/spinner.css \
@@ -37,7 +39,7 @@ css:
 
 js:
 	@mkdir -p dist
-	@cat src/js/base.js src/js/tabs.js src/js/dropdown.js src/js/toast.js src/js/tooltip.js src/js/sidebar.js > dist/oat.js
+	@cat src/js/base.js src/js/tabs.js src/js/dropdown.js src/js/carousel.js src/js/datepicker.js src/js/toast.js src/js/tooltip.js src/js/sidebar.js > dist/oat.js
 	@esbuild dist/oat.js --minify --outfile=dist/oat.min.js
 	@gzip -9 -k -f dist/oat.min.js
 	@cp dist/oat.min.js docs/static/oat.min.js

--- a/docs/content/components/carousel.md
+++ b/docs/content/components/carousel.md
@@ -1,0 +1,79 @@
++++
+title = "Carousel"
+weight = 90
+description = "Horizontal content carousel with keyboard navigation, optional autoplay, and dot controls."
+
+[extra]
+webcomponent = true
++++
+
+Wrap slides in `<ot-carousel>` with a `[data-carousel-track]` container.
+
+{% demo() %}
+```html
+<ot-carousel style="max-width: 34rem;">
+  <div data-carousel-track>
+    <article data-carousel-slide style="padding: var(--space-8); background: var(--muted);">
+      <h4>Slide one</h4>
+      <p>Semantic HTML and tiny CSS/JS footprint.</p>
+    </article>
+    <article data-carousel-slide style="padding: var(--space-8); background: var(--faint);">
+      <h4>Slide two</h4>
+      <p>Keyboard support with Arrow keys, Home, and End.</p>
+    </article>
+    <article data-carousel-slide style="padding: var(--space-8); background: var(--accent);">
+      <h4>Slide three</h4>
+      <p>Works with custom content and custom controls.</p>
+    </article>
+  </div>
+</ot-carousel>
+```
+{% end %}
+
+Carousel supports arrow keys, swipe, and mouse wheel scroll to change slides.
+
+### Autoplay
+
+Set `autoplay` in milliseconds to auto-advance slides. Autoplay pauses on hover/focus and respects reduced motion preferences.
+
+{% demo() %}
+```html
+<ot-carousel autoplay="2500" style="max-width: 34rem;">
+  <div data-carousel-track>
+    <article data-carousel-slide style="padding: var(--space-8); background: var(--muted);">
+      <h4>Fast to build</h4>
+      <p>No external dependencies.</p>
+    </article>
+    <article data-carousel-slide style="padding: var(--space-8); background: var(--faint);">
+      <h4>Small bundles</h4>
+      <p>Carousel logic stays lightweight.</p>
+    </article>
+    <article data-carousel-slide style="padding: var(--space-8); background: var(--accent);">
+      <h4>Accessible defaults</h4>
+      <p>Buttons and dot navigation are automatic.</p>
+    </article>
+  </div>
+</ot-carousel>
+```
+{% end %}
+
+### JavaScript API
+
+```js
+const carousel = document.querySelector('ot-carousel');
+
+carousel.next();
+carousel.prev();
+carousel.goTo(2);      // zero-based index
+carousel.activeIndex;  // current index
+```
+
+### Event
+
+On slide change, the component emits `ot-carousel-change` with `{ index, slide }`.
+
+```js
+document.querySelector('ot-carousel').addEventListener('ot-carousel-change', (e) => {
+  console.log(e.detail.index); // 0, 1, 2...
+});
+```

--- a/docs/content/components/datepicker.md
+++ b/docs/content/components/datepicker.md
@@ -1,0 +1,105 @@
++++
+title = "Datepicker"
+weight = 95
+description = "Calendar date selector with keyboard navigation, min/max limits, and form-friendly ISO values."
+
+[extra]
+webcomponent = true
++++
+
+Wrap an input in `<ot-datepicker>`. Provide an optional ISO date (`YYYY-MM-DD`) in `value`, and optional `min` and `max`.
+
+If the input has a `name`, Oat keeps submission form-friendly by storing ISO in an auto-created hidden input while showing a formatted display value. A calendar SVG icon is added inside the field by default.
+
+{% demo() %}
+```html
+<ot-datepicker>
+  <input type="text" name="start_date" value="2025-06-01" placeholder="Pick a date" />
+</ot-datepicker>
+```
+{% end %}
+
+### JavaScript API
+
+```js
+const picker = document.querySelector('ot-datepicker');
+
+picker.setDate('2025-06-20');        // true
+picker.fetchDate();                  // Date instance
+picker.fetchISODate();               // "2025-06-20"
+picker.fetchDisplayDate();           // Locale-formatted value shown in input
+picker.setMinDate('2025-06-01');     // set lower bound
+picker.setMaxDate('2025-06-30');     // set upper bound
+picker.clearDate();                  // clears current value
+picker.open();                       // opens calendar popover
+picker.close();                      // closes calendar popover
+```
+
+`setDate(value, options)` accepts `Date` or date string input.
+
+- `value`: `Date`, `YYYY-MM-DD`, any valid `Date`-parseable string, or `null`/empty (to clear).
+- `options.emit`: Emit `ot-date-change` (default: `true`).
+- `options.clamp`: Clamp to `min`/`max` instead of failing out-of-range values (default: `true`).
+
+### Date range constraints
+
+Use `min` and `max` to constrain available dates.
+
+{% demo() %}
+```html
+<ot-datepicker>
+  <input
+    type="text"
+    name="billing_date"
+    value="2025-06-15"
+    min="2025-06-10"
+    max="2025-06-25"
+    placeholder="Pick billing date"
+  />
+</ot-datepicker>
+```
+{% end %}
+
+### From-To packed date range
+
+Use `<ot-date-range>` to pack two datepickers as a linked from/to pair.
+
+{% demo() %}
+```html
+<ot-date-range>
+  <ot-datepicker data-range-start>
+    <input type="text" name="from_date" placeholder="From date" />
+  </ot-datepicker>
+  <ot-datepicker data-range-end>
+    <input type="text" name="to_date" placeholder="To date" />
+  </ot-datepicker>
+</ot-date-range>
+```
+{% end %}
+
+When the start date changes, end date minimum is updated automatically.
+When the end date changes, start date maximum is updated automatically.
+
+### Date range JavaScript API
+
+```js
+const range = document.querySelector('ot-date-range');
+
+range.setRange('2025-06-10', '2025-06-20');
+range.setFromDate('2025-06-12');
+range.setToDate('2025-06-26');
+range.fetchRange(); // { from, to, fromDate, toDate }
+range.clearRange();
+```
+
+### Event
+
+On selection (or when changed via JS API with `emit: true`), the component emits `ot-date-change` with `{ value, date }`.
+
+```js
+document.querySelector('ot-datepicker').addEventListener('ot-date-change', (e) => {
+  console.log(e.detail.value); // "2025-06-01"
+});
+```
+
+`<ot-date-range>` emits `ot-date-range-change` with `{ from, to, fromDate, toDate }`.

--- a/src/css/carousel.css
+++ b/src/css/carousel.css
@@ -1,0 +1,123 @@
+@layer components {
+  ot-carousel {
+    position: relative;
+    display: block;
+    overflow: clip;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-large);
+    background-color: var(--card);
+
+    &:focus-visible {
+      outline: 2px solid var(--ring);
+      outline-offset: 2px;
+    }
+
+    [data-carousel-track] {
+      display: flex;
+      transition: transform 240ms cubic-bezier(0.22, 0.61, 0.36, 1);
+      will-change: transform;
+      touch-action: pan-y;
+    }
+
+    [data-carousel-slide] {
+      flex: 0 0 100%;
+      min-width: 100%;
+      opacity: 0.78;
+      transform: scale(0.99);
+      transition: opacity var(--transition), transform var(--transition);
+    }
+
+    [data-carousel-slide][aria-hidden="false"] {
+      opacity: 1;
+      transform: scale(1);
+    }
+
+    [data-carousel-slide] > img {
+      display: block;
+      width: 100%;
+      height: auto;
+    }
+
+    [data-carousel-prev],
+    [data-carousel-next] {
+      position: absolute;
+      top: 50%;
+      z-index: 1;
+      width: 1.5rem;
+      height: 1.5rem;
+      padding: 0;
+      color: var(--foreground);
+      background-color: color-mix(in srgb, var(--background) 70%, transparent);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-full);
+      transform: translateY(-50%);
+      line-height: 1;
+      cursor: pointer;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity var(--transition-fast), background-color var(--transition-fast), transform var(--transition-fast);
+
+      &:is(:hover, :focus-visible) {
+        background-color: var(--accent);
+        transform: translateY(-50%) scale(1.06);
+      }
+    }
+
+    [data-carousel-prev] {
+      inset-inline-start: var(--space-3);
+    }
+
+    [data-carousel-next] {
+      inset-inline-end: var(--space-3);
+    }
+
+    &:is(:hover, :focus-within) {
+      [data-carousel-prev],
+      [data-carousel-next] {
+        opacity: 0.85;
+        pointer-events: auto;
+      }
+    }
+
+    [data-carousel-dots] {
+      position: absolute;
+      inset-block-end: var(--space-3);
+      inset-inline: var(--space-3);
+      display: flex;
+      justify-content: center;
+      gap: var(--space-2);
+      pointer-events: none;
+    }
+
+    [data-carousel-dot] {
+      width: 0.625rem;
+      height: 0.625rem;
+      padding: 0;
+      pointer-events: auto;
+      background-color: color-mix(in srgb, var(--background) 60%, var(--faint));
+      border: 1px solid var(--border);
+      border-radius: var(--radius-full);
+      cursor: pointer;
+      transition: background-color var(--transition-fast), border-color var(--transition-fast), transform var(--transition-fast);
+
+      &:is(:hover, :focus-visible) {
+        background-color: var(--muted-foreground);
+        transform: scale(1.08);
+      }
+
+      &[aria-current="true"] {
+        background-color: var(--foreground);
+        border-color: var(--foreground);
+        transform: scale(1.15);
+      }
+    }
+
+    &[data-carousel-single] {
+      [data-carousel-prev],
+      [data-carousel-next],
+      [data-carousel-dots] {
+        display: none;
+      }
+    }
+  }
+}

--- a/src/css/datepicker.css
+++ b/src/css/datepicker.css
@@ -1,0 +1,191 @@
+@layer components {
+  ot-date-range {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-3);
+    width: min(100%, 34rem);
+
+    > ot-datepicker {
+      width: 100%;
+    }
+
+    @media (max-width: 768px) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  ot-datepicker {
+    position: relative;
+    display: inline-block;
+    width: min(100%, 16rem);
+
+    > input {
+      width: 100%;
+      margin: 0;
+      padding-inline-end: var(--space-8);
+    }
+
+    > [data-datepicker-toggle] {
+      position: absolute;
+      inset-inline-end: var(--space-1);
+      inset-block-start: 50%;
+      transform: translateY(-50%);
+      z-index: 1;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 2rem;
+      height: 2rem;
+      color: var(--muted-foreground);
+      background: none;
+      border: none;
+      border-radius: var(--radius-small);
+      cursor: pointer;
+
+      &::before {
+        content: "";
+        display: block;
+        flex: 0 0 auto;
+        width: 1rem;
+        height: 1rem;
+        background-color: currentColor;
+        mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' stroke='currentColor' stroke-width='2' viewBox='0 0 24 24'%3E%3Crect x='3' y='4' width='18' height='18' rx='2'/%3E%3Cpath d='M16 2v4M8 2v4M3 10h18'/%3E%3C/svg%3E");
+        mask-size: contain;
+        mask-repeat: no-repeat;
+        -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' stroke='currentColor' stroke-width='2' viewBox='0 0 24 24'%3E%3Crect x='3' y='4' width='18' height='18' rx='2'/%3E%3Cpath d='M16 2v4M8 2v4M3 10h18'/%3E%3C/svg%3E");
+        -webkit-mask-size: contain;
+        -webkit-mask-repeat: no-repeat;
+      }
+
+      > [data-datepicker-icon] {
+        width: 1rem;
+        height: 1rem;
+        fill: none;
+        stroke: currentColor;
+        stroke-width: 2;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        display: none;
+      }
+
+      &:is(:hover, :focus-visible) {
+        color: var(--foreground);
+        background-color: transparent;
+      }
+    }
+
+    [data-datepicker-panel] {
+      position: fixed;
+      margin: 0;
+      padding: var(--space-3);
+      min-width: 14rem;
+      max-width: calc(100vw - var(--space-4));
+      background-color: var(--card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-large);
+      box-shadow: var(--shadow-large);
+      opacity: 0;
+      transform: translateY(-4px);
+      transition:
+        opacity 150ms ease-out,
+        transform 150ms ease-out,
+        display 150ms allow-discrete,
+        overlay 150ms allow-discrete;
+
+      &:popover-open {
+        opacity: 1;
+        transform: translateY(0);
+      }
+
+      @starting-style {
+        &:popover-open {
+          opacity: 0;
+          transform: translateY(-4px);
+        }
+      }
+
+      > header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-2);
+        margin-block-end: var(--space-2);
+
+        > strong {
+          font-size: var(--text-7);
+          font-weight: var(--font-semibold);
+        }
+      }
+    }
+
+    [data-datepicker-nav] {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 2rem;
+      height: 2rem;
+      padding: 0;
+      color: var(--foreground);
+      background: none;
+      border: 1px solid transparent;
+      border-radius: var(--radius-small);
+      cursor: pointer;
+
+      &:is(:hover, :focus-visible) {
+        background-color: var(--accent);
+      }
+    }
+
+    [data-datepicker-weekdays],
+    [data-datepicker-days] {
+      display: grid;
+      grid-template-columns: repeat(7, minmax(0, 1fr));
+    }
+
+    [data-datepicker-weekdays] {
+      margin-block-end: var(--space-1);
+
+      > span {
+        text-align: center;
+        font-size: var(--text-8);
+        color: var(--muted-foreground);
+      }
+    }
+
+    [data-day] {
+      width: 2rem;
+      height: 2rem;
+      margin: 1px auto;
+      padding: 0;
+      font-size: var(--text-7);
+      color: var(--foreground);
+      background: none;
+      border: none;
+      border-radius: var(--radius-full);
+      cursor: pointer;
+
+      &:is(:hover, :focus-visible) {
+        background-color: var(--accent);
+      }
+
+      &[data-outside] {
+        color: var(--faint-foreground);
+      }
+
+      &[data-today]:not([aria-selected="true"]) {
+        box-shadow: inset 0 0 0 1px var(--ring);
+      }
+
+      &[aria-selected="true"] {
+        color: var(--background);
+        background-color: var(--foreground);
+      }
+
+      &:disabled {
+        opacity: 0.35;
+        cursor: not-allowed;
+        background: none;
+      }
+    }
+  }
+}

--- a/src/js/carousel.js
+++ b/src/js/carousel.js
@@ -1,0 +1,369 @@
+/**
+ * oat - Carousel Component
+ * Usage:
+ * <ot-carousel>
+ *   <div data-carousel-track>
+ *     <article data-carousel-slide>Slide 1</article>
+ *     <article data-carousel-slide>Slide 2</article>
+ *   </div>
+ * </ot-carousel>
+ */
+
+class OtCarousel extends OtBase {
+  #track;
+  #slides = [];
+  #prevBtn;
+  #nextBtn;
+  #dots;
+  #dotButtons = [];
+  #index = 0;
+  #autoplay = 0;
+  #timer;
+  #pointerId = null;
+  #pointerStartX = 0;
+  #pointerStartY = 0;
+  #wheelCooldownUntil = 0;
+
+  init() {
+    this.#track = this.$(':scope > [data-carousel-track]');
+    this.#slides = this.#track ? [...this.#track.children] : [];
+
+    if (!this.#track || this.#slides.length === 0) {
+      console.warn('ot-carousel: Missing [data-carousel-track] with slide elements');
+      return;
+    }
+
+    this.setAttribute('role', 'region');
+    this.setAttribute('aria-roledescription', 'carousel');
+    this.setAttribute('aria-live', 'off');
+    this.setAttribute('tabindex', this.getAttribute('tabindex') || '0');
+    this.setAttribute('aria-label', this.getAttribute('aria-label') || 'Carousel');
+
+    this.#prevBtn = this.$(':scope > [data-carousel-prev]') || this.#createControl('prev');
+    this.#nextBtn = this.$(':scope > [data-carousel-next]') || this.#createControl('next');
+    this.#dots = this.$(':scope > [data-carousel-dots]') || this.#createDots();
+
+    this.#slides.forEach((slide, i) => {
+      slide.dataset.carouselSlide ||= '';
+      slide.setAttribute('role', 'group');
+      slide.setAttribute('aria-roledescription', 'slide');
+      slide.setAttribute('aria-label', `${i + 1} of ${this.#slides.length}`);
+    });
+
+    this.#syncDots();
+    this.#setIndex(this.#initialIndex(), false, true);
+
+    this.#autoplay = Number.parseInt(this.getAttribute('autoplay') || '0', 10);
+    if (this.#slides.length < 2) {
+      this.dataset.carouselSingle = '';
+    } else {
+      delete this.dataset.carouselSingle;
+      this.#startAutoplay();
+    }
+
+    this.addEventListener('click', this);
+    this.addEventListener('keydown', this);
+    this.addEventListener('mouseenter', this);
+    this.addEventListener('mouseleave', this);
+    this.addEventListener('focusin', this);
+    this.addEventListener('focusout', this);
+    this.addEventListener('wheel', this, { passive: false });
+    this.#track.addEventListener('pointerdown', this);
+    this.#track.addEventListener('pointerup', this);
+    this.#track.addEventListener('pointercancel', this);
+  }
+
+  cleanup() {
+    this.#stopAutoplay();
+  }
+
+  onclick(e) {
+    const control = e.target.closest('[data-carousel-prev], [data-carousel-next], [data-carousel-dot]');
+    if (!control || !this.contains(control)) {
+      return;
+    }
+
+    if (control.hasAttribute('data-carousel-prev')) {
+      this.prev();
+      return;
+    }
+
+    if (control.hasAttribute('data-carousel-next')) {
+      this.next();
+      return;
+    }
+
+    const index = Number.parseInt(control.dataset.index || '-1', 10);
+    if (index >= 0) {
+      this.goTo(index);
+    }
+  }
+
+  onkeydown(e) {
+    if (e.altKey || e.ctrlKey || e.metaKey) {
+      return;
+    }
+
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      this.prev();
+      return;
+    }
+
+    if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      this.next();
+      return;
+    }
+
+    if (e.key === 'Home') {
+      e.preventDefault();
+      this.goTo(0);
+      return;
+    }
+
+    if (e.key === 'End') {
+      e.preventDefault();
+      this.goTo(this.#slides.length - 1);
+    }
+  }
+
+  onmouseenter() {
+    this.#stopAutoplay();
+  }
+
+  onmouseleave() {
+    this.#startAutoplay();
+  }
+
+  onfocusin() {
+    this.#stopAutoplay();
+  }
+
+  onfocusout(e) {
+    if (!this.contains(e.relatedTarget)) {
+      this.#startAutoplay();
+    }
+  }
+
+  onpointerdown(e) {
+    if (this.#slides.length < 2) {
+      return;
+    }
+
+    if (e.pointerType === 'mouse' && e.button !== 0) {
+      return;
+    }
+
+    this.#pointerId = e.pointerId;
+    this.#pointerStartX = e.clientX;
+    this.#pointerStartY = e.clientY;
+    this.#track.setPointerCapture?.(e.pointerId);
+  }
+
+  onpointerup(e) {
+    if (e.pointerId !== this.#pointerId) {
+      return;
+    }
+
+    const dx = e.clientX - this.#pointerStartX;
+    const dy = e.clientY - this.#pointerStartY;
+    this.#pointerId = null;
+
+    if (Math.abs(dx) < 40 || Math.abs(dx) < Math.abs(dy)) {
+      return;
+    }
+
+    if (dx > 0) {
+      this.prev();
+    } else {
+      this.next();
+    }
+  }
+
+  onpointercancel() {
+    this.#pointerId = null;
+  }
+
+  onwheel(e) {
+    if (this.#slides.length < 2) {
+      return;
+    }
+
+    const now = performance.now();
+    if (now < this.#wheelCooldownUntil) {
+      return;
+    }
+
+    const delta = Math.abs(e.deltaY) >= Math.abs(e.deltaX) ? e.deltaY : e.deltaX;
+    if (Math.abs(delta) < 18) {
+      return;
+    }
+
+    e.preventDefault();
+    this.#wheelCooldownUntil = now + 220;
+
+    if (delta > 0) {
+      this.next();
+    } else {
+      this.prev();
+    }
+  }
+
+  next() {
+    return this.goTo(this.#index + 1);
+  }
+
+  prev() {
+    return this.goTo(this.#index - 1);
+  }
+
+  goTo(index) {
+    const changed = this.#setIndex(index, true, false);
+    if (changed) {
+      this.#restartAutoplay();
+    }
+    return changed;
+  }
+
+  get activeIndex() {
+    return this.#index;
+  }
+
+  set activeIndex(value) {
+    this.goTo(value);
+  }
+
+  #initialIndex() {
+    const start = Number.parseInt(this.getAttribute('start') || '0', 10);
+    if (Number.isNaN(start)) {
+      return 0;
+    }
+    return Math.max(0, Math.min(start, this.#slides.length - 1));
+  }
+
+  #setIndex(index, emit = true, force = false) {
+    if (!this.#slides.length) {
+      return false;
+    }
+
+    const len = this.#slides.length;
+    const next = ((index % len) + len) % len;
+    const changed = next !== this.#index;
+
+    if (!changed && !force) {
+      return false;
+    }
+
+    this.#index = next;
+    this.#track.style.transform = `translateX(-${next * 100}%)`;
+    this.#track.setAttribute('aria-label', `Slide ${next + 1} of ${len}`);
+
+    this.#slides.forEach((slide, i) => {
+      const active = i === next;
+      slide.setAttribute('aria-hidden', String(!active));
+    });
+
+    this.#dotButtons.forEach((dot, i) => {
+      const active = i === next;
+      dot.setAttribute('aria-current', active ? 'true' : 'false');
+      dot.ariaLabel = `Go to slide ${i + 1}`;
+    });
+
+    if (emit) {
+      this.emit('ot-carousel-change', {
+        index: next,
+        slide: this.#slides[next]
+      });
+    }
+
+    return true;
+  }
+
+  #createControl(direction) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+
+    if (direction === 'prev') {
+      btn.dataset.carouselPrev = '';
+      btn.setAttribute('aria-label', 'Previous slide');
+      btn.innerHTML = '&#x2039;';
+    } else {
+      btn.dataset.carouselNext = '';
+      btn.setAttribute('aria-label', 'Next slide');
+      btn.innerHTML = '&#x203a;';
+    }
+
+    this.append(btn);
+    return btn;
+  }
+
+  #createDots() {
+    const nav = document.createElement('nav');
+    nav.dataset.carouselDots = '';
+    nav.setAttribute('aria-label', 'Slide navigation');
+    this.append(nav);
+    return nav;
+  }
+
+  #syncDots() {
+    const current = [...this.#dots.querySelectorAll('[data-carousel-dot]')];
+    const len = this.#slides.length;
+
+    if (current.length > len) {
+      current.slice(len).forEach(dot => dot.remove());
+    }
+
+    if (current.length < len) {
+      for (let i = current.length; i < len; i++) {
+        const dot = document.createElement('button');
+        dot.type = 'button';
+        dot.dataset.carouselDot = '';
+        dot.dataset.index = String(i);
+        this.#dots.append(dot);
+      }
+    }
+
+    this.#dotButtons = [...this.#dots.querySelectorAll('[data-carousel-dot]')].slice(0, len);
+    this.#dotButtons.forEach((dot, i) => {
+      if (dot instanceof HTMLButtonElement) {
+        dot.type = 'button';
+      }
+      dot.dataset.index = String(i);
+      dot.setAttribute('aria-label', `Go to slide ${i + 1}`);
+    });
+  }
+
+  #startAutoplay() {
+    this.#stopAutoplay();
+
+    if (this.#autoplay <= 0 || this.#slides.length < 2) {
+      return;
+    }
+
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      return;
+    }
+
+    if (this.matches(':hover') || this.contains(document.activeElement)) {
+      return;
+    }
+
+    this.#timer = setInterval(() => {
+      this.#setIndex(this.#index + 1, true, false);
+    }, this.#autoplay);
+  }
+
+  #stopAutoplay() {
+    if (this.#timer) {
+      clearInterval(this.#timer);
+      this.#timer = null;
+    }
+  }
+
+  #restartAutoplay() {
+    this.#startAutoplay();
+  }
+}
+
+customElements.define('ot-carousel', OtCarousel);

--- a/src/js/datepicker.js
+++ b/src/js/datepicker.js
@@ -1,0 +1,792 @@
+/**
+ * oat - Datepicker Component
+ * Usage:
+ * <ot-datepicker>
+ *   <input type="text" name="start_date" value="2025-06-01" placeholder="Select date" />
+ * </ot-datepicker>
+ */
+
+class OtDatepicker extends OtBase {
+  #input;
+  #submitInput;
+  #panel;
+  #toggle;
+  #monthLabel;
+  #daysGrid;
+  #viewDate;
+  #selectedDate;
+  #minDate;
+  #maxDate;
+  #position;
+  #locale;
+  #displayFmt;
+  #monthFmt;
+
+  init() {
+    this.#input = this.$(':scope > input') || this.$('input') || this.#createInput();
+    if (!this.#input) return;
+
+    this.#setupInput();
+    this.#buildUI();
+
+    this.#locale = this.getAttribute('locale') || document.documentElement.lang || 'en-US';
+    this.#displayFmt = new Intl.DateTimeFormat(this.#locale, {
+      month: 'long',
+      day: '2-digit',
+      year: 'numeric'
+    });
+    this.#monthFmt = new Intl.DateTimeFormat(this.#locale, {
+      month: 'long',
+      year: 'numeric'
+    });
+
+    this.#minDate = this.#parseDate(this.#input.getAttribute('min'));
+    this.#maxDate = this.#parseDate(this.#input.getAttribute('max'));
+
+    const preset = this.#parseDate(this.#input.dataset.value || this.#input.value);
+    this.#selectedDate = preset && this.#inRange(preset) ? preset : null;
+    this.#viewDate = this.#selectedDate ? this.#startOfMonth(this.#selectedDate) : this.#startOfMonth(this.#today());
+
+    this.#syncInput();
+    this.#render();
+
+    this.#position = () => this.#placePanel();
+    this.#input.addEventListener('click', this);
+    this.#input.addEventListener('keydown', this);
+    this.#panel.addEventListener('click', this);
+    this.#panel.addEventListener('keydown', this);
+    this.#panel.addEventListener('toggle', this);
+  }
+
+  cleanup() {
+    window.removeEventListener('resize', this.#position);
+    window.removeEventListener('scroll', this.#position, true);
+  }
+
+  onclick(e) {
+    if (e.target === this.#input) {
+      requestAnimationFrame(() => this.#open());
+      return;
+    }
+
+    const nav = e.target.closest('[data-datepicker-nav]');
+    if (nav) {
+      this.#viewDate = this.#addMonths(this.#viewDate, nav.dataset.datepickerNav === 'prev' ? -1 : 1);
+      this.#render();
+      this.#focusActiveDay();
+      return;
+    }
+
+    const day = e.target.closest('[data-day]');
+    if (!day || day.disabled) {
+      return;
+    }
+
+    const date = this.#parseDate(day.dataset.date);
+    if (!date || !this.#inRange(date)) {
+      return;
+    }
+
+    this.#applySelectedDate(date, true);
+    this.#close();
+    this.#input.focus();
+  }
+
+  onkeydown(e) {
+    if (e.target === this.#input) {
+      if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        this.#open();
+        this.#focusActiveDay();
+      } else if (e.key === 'Escape') {
+        this.#close();
+      }
+      return;
+    }
+
+    const day = e.target.closest('[data-day]');
+    if (!day) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        this.#close();
+        this.#input.focus();
+      }
+      return;
+    }
+
+    const date = this.#parseDate(day.dataset.date);
+    if (!date) return;
+
+    let next = null;
+    if (e.key === 'ArrowLeft') next = this.#addDays(date, -1);
+    if (e.key === 'ArrowRight') next = this.#addDays(date, 1);
+    if (e.key === 'ArrowUp') next = this.#addDays(date, -7);
+    if (e.key === 'ArrowDown') next = this.#addDays(date, 7);
+    if (e.key === 'Home') next = this.#addDays(date, -date.getDay());
+    if (e.key === 'End') next = this.#addDays(date, 6 - date.getDay());
+    if (e.key === 'PageUp') next = this.#addMonths(date, -1);
+    if (e.key === 'PageDown') next = this.#addMonths(date, 1);
+
+    if (next) {
+      e.preventDefault();
+      this.#focusDate(this.#clampDate(next));
+      return;
+    }
+
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      this.#close();
+      this.#input.focus();
+    }
+  }
+
+  ontoggle(e) {
+    if (e.newState === 'open') {
+      this.#placePanel();
+      window.addEventListener('resize', this.#position);
+      window.addEventListener('scroll', this.#position, true);
+      this.#focusActiveDay();
+    } else {
+      this.cleanup();
+    }
+  }
+
+  fetchDate() {
+    return this.#selectedDate ? new Date(this.#selectedDate.getTime()) : null;
+  }
+
+  fetchISODate() {
+    return this.#selectedDate ? this.#formatISO(this.#selectedDate) : null;
+  }
+
+  fetchDisplayDate() {
+    return this.#input?.value || '';
+  }
+
+  fetchMinDate() {
+    return this.#minDate ? new Date(this.#minDate.getTime()) : null;
+  }
+
+  fetchMaxDate() {
+    return this.#maxDate ? new Date(this.#maxDate.getTime()) : null;
+  }
+
+  setDate(value, options = {}) {
+    if (!this.#input) return false;
+
+    const { emit = true, clamp = true } = options;
+
+    if (value === null || value === undefined || value === '') {
+      return this.clearDate({ emit });
+    }
+
+    const parsed = this.#parseDate(value);
+    if (!parsed) return false;
+
+    const date = clamp ? this.#clampDate(parsed) : parsed;
+    if (!this.#inRange(date)) return false;
+
+    this.#applySelectedDate(date, emit);
+    return true;
+  }
+
+  setMinDate(value, options = {}) {
+    if (!this.#input) return false;
+
+    const { clamp = true, emit = false } = options;
+
+    if (value === null || value === undefined || value === '') {
+      this.#minDate = null;
+      this.#input.removeAttribute('min');
+      this.#refreshAfterConstraintChange(clamp, emit);
+      return true;
+    }
+
+    const parsed = this.#parseDate(value);
+    if (!parsed) return false;
+
+    this.#minDate = parsed;
+    this.#input.setAttribute('min', this.#formatISO(parsed));
+
+    if (this.#maxDate && this.#maxDate < this.#minDate) {
+      this.#maxDate = new Date(this.#minDate.getTime());
+      this.#input.setAttribute('max', this.#formatISO(this.#maxDate));
+    }
+
+    this.#refreshAfterConstraintChange(clamp, emit);
+    return true;
+  }
+
+  setMaxDate(value, options = {}) {
+    if (!this.#input) return false;
+
+    const { clamp = true, emit = false } = options;
+
+    if (value === null || value === undefined || value === '') {
+      this.#maxDate = null;
+      this.#input.removeAttribute('max');
+      this.#refreshAfterConstraintChange(clamp, emit);
+      return true;
+    }
+
+    const parsed = this.#parseDate(value);
+    if (!parsed) return false;
+
+    this.#maxDate = parsed;
+    this.#input.setAttribute('max', this.#formatISO(parsed));
+
+    if (this.#minDate && this.#minDate > this.#maxDate) {
+      this.#minDate = new Date(this.#maxDate.getTime());
+      this.#input.setAttribute('min', this.#formatISO(this.#minDate));
+    }
+
+    this.#refreshAfterConstraintChange(clamp, emit);
+    return true;
+  }
+
+  clearDate(options = {}) {
+    if (!this.#input) return false;
+
+    const { emit = true } = options;
+    const hadSelection = Boolean(this.#selectedDate);
+
+    this.#selectedDate = null;
+    this.#viewDate = this.#startOfMonth(this.#today());
+    this.#syncInput();
+    this.#render();
+    if (emit && hadSelection) this.#emitDateChange();
+    return true;
+  }
+
+  open() {
+    if (!this.#panel || !this.#input) return;
+    this.#open();
+  }
+
+  close() {
+    if (!this.#panel) return;
+    this.#close();
+  }
+
+  #buildUI() {
+    this.#panel = this.$(':scope > [data-datepicker-panel]');
+    if (!this.#panel) {
+      this.#panel = document.createElement('section');
+      this.#panel.dataset.datepickerPanel = '';
+      this.#panel.setAttribute('popover', '');
+      this.#panel.innerHTML = `
+        <header>
+          <button type="button" data-datepicker-nav="prev" aria-label="Previous month">&#x2039;</button>
+          <strong data-datepicker-month aria-live="polite"></strong>
+          <button type="button" data-datepicker-nav="next" aria-label="Next month">&#x203a;</button>
+        </header>
+        <div data-datepicker-weekdays aria-hidden="true"></div>
+        <div data-datepicker-days role="grid" aria-label="Calendar"></div>
+      `;
+      this.append(this.#panel);
+    }
+
+    this.#panel.id ||= `ot-datepicker-${this.uid()}`;
+    this.#monthLabel = this.#panel.querySelector('[data-datepicker-month]');
+    this.#daysGrid = this.#panel.querySelector('[data-datepicker-days]');
+
+    this.#toggle = this.$(':scope > [data-datepicker-toggle]') || this.#createToggle();
+    this.#toggle.setAttribute('type', 'button');
+    this.#toggle.setAttribute('aria-label', 'Toggle calendar');
+    this.#toggle.setAttribute('popovertarget', this.#panel.id);
+    this.#ensureToggleIcon(this.#toggle);
+    if (this.#input.disabled) {
+      this.#toggle.disabled = true;
+    }
+
+    const weekdays = this.#panel.querySelector('[data-datepicker-weekdays]');
+    if (!weekdays?.children.length) {
+      ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'].forEach(day => {
+        const cell = document.createElement('span');
+        cell.textContent = day;
+        weekdays.append(cell);
+      });
+    }
+  }
+
+  #createToggle() {
+    const btn = document.createElement('button');
+    btn.dataset.datepickerToggle = '';
+    btn.append(this.#createCalendarIcon());
+    this.append(btn);
+    return btn;
+  }
+
+  #ensureToggleIcon(toggle) {
+    if (!toggle || toggle.querySelector('[data-datepicker-icon]')) return;
+    toggle.prepend(this.#createCalendarIcon());
+  }
+
+  #createCalendarIcon() {
+    const svgNs = 'http://www.w3.org/2000/svg';
+    const icon = document.createElementNS(svgNs, 'svg');
+    icon.dataset.datepickerIcon = '';
+    icon.setAttribute('viewBox', '0 0 24 24');
+    icon.setAttribute('width', '16');
+    icon.setAttribute('height', '16');
+    icon.setAttribute('aria-hidden', 'true');
+    icon.setAttribute('focusable', 'false');
+    icon.setAttribute('fill', 'none');
+    icon.setAttribute('stroke', 'currentColor');
+    icon.setAttribute('stroke-width', '2');
+    icon.setAttribute('stroke-linecap', 'round');
+    icon.setAttribute('stroke-linejoin', 'round');
+    icon.style.display = 'block';
+
+    const rect = document.createElementNS(svgNs, 'rect');
+    rect.setAttribute('x', '3');
+    rect.setAttribute('y', '4');
+    rect.setAttribute('width', '18');
+    rect.setAttribute('height', '18');
+    rect.setAttribute('rx', '2');
+    rect.setAttribute('fill', 'none');
+    rect.setAttribute('stroke', 'currentColor');
+    rect.setAttribute('stroke-width', '2');
+
+    const path = document.createElementNS(svgNs, 'path');
+    path.setAttribute('d', 'M16 2v4M8 2v4M3 10h18');
+    path.setAttribute('fill', 'none');
+    path.setAttribute('stroke', 'currentColor');
+    path.setAttribute('stroke-width', '2');
+    path.setAttribute('stroke-linecap', 'round');
+    path.setAttribute('stroke-linejoin', 'round');
+
+    icon.append(rect, path);
+    return icon;
+  }
+
+  #createInput() {
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.placeholder = 'Select date';
+    this.prepend(input);
+    return input;
+  }
+
+  #setupInput() {
+    this.#input.type = 'text';
+    this.#input.readOnly = true;
+    this.#input.autocomplete = 'off';
+    this.#input.setAttribute('aria-haspopup', 'dialog');
+
+    if (this.#input.name) {
+      this.#submitInput = document.createElement('input');
+      this.#submitInput.type = 'hidden';
+      this.#submitInput.name = this.#input.name;
+      this.#input.removeAttribute('name');
+      this.#input.insertAdjacentElement('afterend', this.#submitInput);
+    }
+  }
+
+  #open() {
+    if (!this.#panel.matches(':popover-open') && !this.#input.disabled) {
+      this.#panel.showPopover();
+    }
+  }
+
+  #close() {
+    if (this.#panel.matches(':popover-open')) {
+      this.#panel.hidePopover();
+    }
+  }
+
+  #applySelectedDate(date, emit = true) {
+    this.#selectedDate = date;
+    this.#viewDate = this.#startOfMonth(date);
+    this.#syncInput();
+    this.#render();
+    if (emit) this.#emitDateChange();
+  }
+
+  #emitDateChange() {
+    this.emit('ot-date-change', {
+      value: this.#selectedDate ? this.#formatISO(this.#selectedDate) : null,
+      date: this.#selectedDate ? new Date(this.#selectedDate.getTime()) : null
+    });
+  }
+
+  #placePanel() {
+    const trigger = this.#input.getBoundingClientRect();
+    const panel = this.#panel.getBoundingClientRect();
+    const gap = 8;
+
+    let top = trigger.top - panel.height - gap;
+    if (top < gap && trigger.bottom + panel.height + gap <= window.innerHeight) {
+      top = trigger.bottom + gap;
+    }
+    top = Math.max(gap, top);
+
+    let left = trigger.left;
+    if (left + panel.width > window.innerWidth - gap) {
+      left = window.innerWidth - panel.width - gap;
+    }
+    left = Math.max(gap, left);
+
+    this.#panel.style.top = `${Math.round(top)}px`;
+    this.#panel.style.left = `${Math.round(left)}px`;
+  }
+
+  #render() {
+    this.#monthLabel.textContent = this.#monthFmt.format(this.#viewDate);
+    this.#daysGrid.textContent = '';
+
+    const fragment = document.createDocumentFragment();
+    const first = this.#startOfMonth(this.#viewDate);
+    const start = this.#addDays(first, -first.getDay());
+    const today = this.#today();
+
+    for (let i = 0; i < 42; i++) {
+      const date = this.#addDays(start, i);
+      const iso = this.#formatISO(date);
+      const btn = document.createElement('button');
+      const inMonth = date.getMonth() === first.getMonth();
+      const disabled = !this.#inRange(date);
+
+      btn.type = 'button';
+      btn.dataset.day = '';
+      btn.dataset.date = iso;
+      btn.textContent = String(date.getDate());
+      btn.setAttribute('aria-label', this.#displayFmt.format(date));
+      btn.setAttribute('aria-selected', this.#isSameDay(date, this.#selectedDate) ? 'true' : 'false');
+      btn.tabIndex = -1;
+
+      if (!inMonth) {
+        btn.dataset.outside = '';
+      }
+      if (this.#isSameDay(date, today)) {
+        btn.dataset.today = '';
+      }
+      if (disabled) {
+        btn.disabled = true;
+      }
+
+      fragment.append(btn);
+    }
+
+    this.#daysGrid.append(fragment);
+    this.#setFocusableDay(this.#selectedDate || today);
+  }
+
+  #focusActiveDay() {
+    const active = this.#daysGrid.querySelector('[data-day][tabindex="0"]:not(:disabled)');
+    active?.focus();
+  }
+
+  #focusDate(date) {
+    if (!date) return;
+
+    this.#viewDate = this.#startOfMonth(date);
+    this.#render();
+
+    const btn = this.#daysGrid.querySelector(`[data-date="${this.#formatISO(date)}"]:not(:disabled)`);
+    if (btn) {
+      this.#daysGrid.querySelectorAll('[data-day]').forEach(el => el.tabIndex = -1);
+      btn.tabIndex = 0;
+      btn.focus();
+    }
+  }
+
+  #setFocusableDay(fallbackDate) {
+    const match = fallbackDate && this.#daysGrid.querySelector(`[data-date="${this.#formatISO(fallbackDate)}"]:not(:disabled)`);
+    const first = this.#daysGrid.querySelector('[data-day]:not(:disabled)');
+    const target = match || first;
+
+    this.#daysGrid.querySelectorAll('[data-day]').forEach(day => day.tabIndex = -1);
+    if (target) {
+      target.tabIndex = 0;
+    }
+  }
+
+  #syncInput() {
+    if (!this.#selectedDate) {
+      this.#input.value = '';
+      delete this.#input.dataset.value;
+      if (this.#submitInput) this.#submitInput.value = '';
+      return;
+    }
+
+    const iso = this.#formatISO(this.#selectedDate);
+    this.#input.value = this.#displayFmt.format(this.#selectedDate);
+    this.#input.dataset.value = iso;
+    if (this.#submitInput) this.#submitInput.value = iso;
+  }
+
+  #refreshAfterConstraintChange(clamp, emit) {
+    if (this.#selectedDate && !this.#inRange(this.#selectedDate)) {
+      if (clamp) {
+        const clamped = this.#clampDate(this.#selectedDate);
+        this.#applySelectedDate(clamped, emit);
+      } else {
+        this.clearDate({ emit });
+      }
+      return;
+    }
+
+    this.#render();
+  }
+
+  #clampDate(date) {
+    if (this.#minDate && date < this.#minDate) return this.#minDate;
+    if (this.#maxDate && date > this.#maxDate) return this.#maxDate;
+    return date;
+  }
+
+  #inRange(date) {
+    if (this.#minDate && date < this.#minDate) return false;
+    if (this.#maxDate && date > this.#maxDate) return false;
+    return true;
+  }
+
+  #parseDate(input) {
+    if (!input) return null;
+    if (input instanceof Date && !Number.isNaN(input.getTime())) {
+      return this.#toDay(input);
+    }
+
+    if (/^\d{4}-\d{2}-\d{2}$/.test(input)) {
+      const [y, m, d] = input.split('-').map(Number);
+      const date = new Date(y, m - 1, d);
+      if (date.getFullYear() === y && date.getMonth() === m - 1 && date.getDate() === d) {
+        return date;
+      }
+      return null;
+    }
+
+    const date = new Date(input);
+    return Number.isNaN(date.getTime()) ? null : this.#toDay(date);
+  }
+
+  #today() {
+    return this.#toDay(new Date());
+  }
+
+  #toDay(date) {
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  }
+
+  #startOfMonth(date) {
+    return new Date(date.getFullYear(), date.getMonth(), 1);
+  }
+
+  #addDays(date, n) {
+    const out = new Date(date.getFullYear(), date.getMonth(), date.getDate() + n);
+    return this.#toDay(out);
+  }
+
+  #addMonths(date, n) {
+    return new Date(date.getFullYear(), date.getMonth() + n, 1);
+  }
+
+  #formatISO(date) {
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+  }
+
+  #isSameDay(a, b) {
+    return Boolean(a && b &&
+      a.getFullYear() === b.getFullYear() &&
+      a.getMonth() === b.getMonth() &&
+      a.getDate() === b.getDate());
+  }
+}
+
+customElements.define('ot-datepicker', OtDatepicker);
+
+class OtDateRange extends OtBase {
+  #startPicker;
+  #endPicker;
+  #onStartChange;
+  #onEndChange;
+  #updating = false;
+
+  init() {
+    this.setAttribute('role', 'group');
+    this.setAttribute('aria-label', this.getAttribute('aria-label') || 'Date range');
+
+    this.#resolvePickers();
+
+    this.#onStartChange = () => this.#handleStartChange();
+    this.#onEndChange = () => this.#handleEndChange();
+    this.#startPicker?.addEventListener('ot-date-change', this.#onStartChange);
+    this.#endPicker?.addEventListener('ot-date-change', this.#onEndChange);
+
+    requestAnimationFrame(() => {
+      this.#syncConstraints();
+    });
+  }
+
+  cleanup() {
+    if (this.#onStartChange) {
+      this.#startPicker?.removeEventListener('ot-date-change', this.#onStartChange);
+    }
+    if (this.#onEndChange) {
+      this.#endPicker?.removeEventListener('ot-date-change', this.#onEndChange);
+    }
+  }
+
+  fetchRange() {
+    const fromDate = this.#startPicker?.fetchDate() || null;
+    const toDate = this.#endPicker?.fetchDate() || null;
+
+    return {
+      from: this.#startPicker?.fetchISODate() || null,
+      to: this.#endPicker?.fetchISODate() || null,
+      fromDate,
+      toDate
+    };
+  }
+
+  setFromDate(value, options = {}) {
+    if (!this.#startPicker || !this.#endPicker) return false;
+
+    const { emit = true, clamp = true } = options;
+    const hasValue = !(value === null || value === undefined || value === '');
+
+    this.#updating = true;
+    const ok = this.#startPicker.setDate(value, { emit: false, clamp });
+    if (hasValue && !ok) {
+      this.#updating = false;
+      return false;
+    }
+
+    this.#applyStartConstraint();
+    this.#updating = false;
+
+    if (emit) this.#emitRangeChange();
+    return true;
+  }
+
+  setToDate(value, options = {}) {
+    if (!this.#startPicker || !this.#endPicker) return false;
+
+    const { emit = true, clamp = true } = options;
+    const hasValue = !(value === null || value === undefined || value === '');
+
+    this.#updating = true;
+    const ok = this.#endPicker.setDate(value, { emit: false, clamp });
+    if (hasValue && !ok) {
+      this.#updating = false;
+      return false;
+    }
+
+    this.#applyEndConstraint();
+    this.#updating = false;
+
+    if (emit) this.#emitRangeChange();
+    return true;
+  }
+
+  setRange(from, to, options = {}) {
+    const { emit = true, clamp = true } = options;
+
+    const fromOk = this.setFromDate(from, { emit: false, clamp });
+    if (!fromOk) return false;
+
+    const toOk = this.setToDate(to, { emit: false, clamp });
+    if (!toOk) return false;
+
+    if (emit) this.#emitRangeChange();
+    return true;
+  }
+
+  clearRange(options = {}) {
+    const { emit = true } = options;
+    return this.setRange(null, null, { emit, clamp: true });
+  }
+
+  #resolvePickers() {
+    const pickers = this.$$(':scope > ot-datepicker');
+
+    this.#startPicker =
+      this.$(':scope > ot-datepicker[data-range-start]') ||
+      pickers[0] ||
+      this.#createPicker('start');
+
+    this.#endPicker =
+      this.$(':scope > ot-datepicker[data-range-end]') ||
+      pickers.find(p => p !== this.#startPicker) ||
+      this.#createPicker('end');
+
+    if (this.#startPicker === this.#endPicker) {
+      this.#endPicker = this.#createPicker('end');
+    }
+
+    this.#startPicker.dataset.rangeStart = '';
+    this.#endPicker.dataset.rangeEnd = '';
+  }
+
+  #createPicker(type) {
+    const picker = document.createElement('ot-datepicker');
+    const input = document.createElement('input');
+    const isStart = type === 'start';
+
+    input.type = 'text';
+    input.name = this.getAttribute(isStart ? 'from-name' : 'to-name') || (isStart ? 'from_date' : 'to_date');
+    input.placeholder = this.getAttribute(isStart ? 'from-placeholder' : 'to-placeholder') || (isStart ? 'From date' : 'To date');
+
+    picker.append(input);
+    this.append(picker);
+    return picker;
+  }
+
+  #handleStartChange() {
+    if (this.#updating) return;
+    this.#updating = true;
+    this.#applyStartConstraint();
+    this.#updating = false;
+    this.#emitRangeChange();
+  }
+
+  #handleEndChange() {
+    if (this.#updating) return;
+    this.#updating = true;
+    this.#applyEndConstraint();
+    this.#updating = false;
+    this.#emitRangeChange();
+  }
+
+  #applyStartConstraint() {
+    const fromDate = this.#startPicker.fetchDate();
+    const fromISO = this.#startPicker.fetchISODate();
+    this.#endPicker.setMinDate(fromISO, { clamp: true, emit: false });
+
+    const toDate = this.#endPicker.fetchDate();
+    if (fromDate && toDate && toDate < fromDate) {
+      this.#endPicker.setDate(fromDate, { emit: false, clamp: true });
+    }
+  }
+
+  #applyEndConstraint() {
+    const toDate = this.#endPicker.fetchDate();
+    const toISO = this.#endPicker.fetchISODate();
+    this.#startPicker.setMaxDate(toISO, { clamp: true, emit: false });
+
+    const fromDate = this.#startPicker.fetchDate();
+    if (fromDate && toDate && fromDate > toDate) {
+      this.#startPicker.setDate(toDate, { emit: false, clamp: true });
+    }
+  }
+
+  #syncConstraints() {
+    if (!this.#startPicker || !this.#endPicker) return;
+
+    this.#updating = true;
+    this.#applyStartConstraint();
+    this.#applyEndConstraint();
+    this.#updating = false;
+  }
+
+  #emitRangeChange() {
+    const detail = this.fetchRange();
+    this.emit('ot-date-range-change', detail);
+  }
+}
+
+customElements.define('ot-date-range', OtDateRange);


### PR DESCRIPTION
## Summary
Adds a new `ot-carousel` component and expands datepicker capabilities with linked from/to range behavior and richer public APIs.

## Changes
- Added `ot-carousel` implementation and styles.
- Added datepicker enhancements including:
  - `setMinDate`, `setMaxDate`, `fetchMinDate`, `fetchMaxDate`
  - `ot-date-range` wrapper component with linked constraints and range events
- Updated component docs for carousel and datepicker usage/API.
- Updated build wiring in `Makefile` to include new component assets.
- Added `.gitignore` entries for local tooling/dependency folders (`node_modules`, `.tools`).

## Motivation
These changes provide a lightweight, framework-free carousel and a practical date range picker workflow needed in real forms while keeping Oat's semantic HTML + minimal JS philosophy.

## Testing
- Built assets successfully with:
  - `make dist`
- Built docs successfully with:
  - `cd docs && ../.tools/zola build`
- Verified branch diff is clean and focused against `upstream/master`.