### PR TITLE
Fix: locked scolling on dialog open

### DIFF
--- a/src/js/dialog.js
+++ b/src/js/dialog.js
@@ -1,0 +1,22 @@
+/**
+ * oat - Dialog Scroll Lock
+ * Automatically locks body scrolling when a native <dialog> is open.
+*/
+document.addEventListener("DOMContentLoaded", () => {
+  
+  const observer = new MutationObserver((mutations) => {
+    const isDialogOpen = !!document.querySelector('dialog[open]');
+    
+    if (isDialogOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+  });
+
+  observer.observe(document.body, { 
+    attributes: true, 
+    subtree: true, 
+    attributeFilter: ['open'] 
+  });
+});

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -3,6 +3,7 @@ import './tabs.js';
 import './dropdown.js';
 import './tooltip.js';
 import './sidebar.js';
+import './dialog.js';
 import { toast, toastEl, toastClear } from './toast.js';
 
 // Register the global window.ot.* APIs.


### PR DESCRIPTION
### Summary
Fixes an issue where the page continued to scroll when a dialog was opened.

### Problem
Opening the dialog did not lock background scrolling, which caused
unexpected UI behavior and poor user experience.

### Solution
Added scroll locking when the dialog is active and restored scrolling
when it closes.