### PR TITLE
docs: add oat-animate to Oat Extensions list

### DIFF
--- a/docs/content/extensions.md
+++ b/docs/content/extensions.md
@@ -7,5 +7,8 @@ Third-party extensions that work with Oat.
 
 - **[oat-chips](https://github.com/someshkar/oat-chips)**: Chip/tag component with dismissible filters, colors, and toggle selection. ~1KB gzipped ([Demo](https://oat-chips.somesh.dev)).
 
+- **[oat-animate](https://github.com/dharmeshgurnani/oat-animate)**: Lightweight animation extension for Oat with declarative `ot-animate` triggers (`on-load`, `hover`, `in-view`) and reduced-motion support. ~1kb gzipped ([Demo](https://oat-animate.dharmeshgurnani.com)).
+
+
 -------
 [Open a PR](https://github.com/knadh/oat) to list an extension here.


### PR DESCRIPTION
Add oat-animate as extension in the Oat “Extensions” page, including GitHub repository and live demo links.