### PR TITLE
 Fix topnav-main underflow when not sidebar-layout

### DIFF
--- a/src/css/sidebar.css
+++ b/src/css/sidebar.css
@@ -101,7 +101,6 @@
   }
 
   nav[data-topnav] {
-    --topnav-offset: var(--space-12);
     position: fixed;
     inset: 0 0 auto;
     z-index: 5;
@@ -115,6 +114,7 @@
     box-shadow: var(--shadow-small);
 
     + main {
+      --topnav-offset: var(--space-12);
       min-width: 0;
       margin-block-start: var(--topnav-offset);
       padding-block-start: var(--space-8);


### PR DESCRIPTION
Currently when using oats suggested layout excluding sidebar the topbar & main collide:

<img width="1428" height="365" alt="image" src="https://github.com/user-attachments/assets/f5500c59-716d-4c0c-bb49-f25de300d939" />

This is due to the *sidebar layout* adding an margin/padding at the start rather than `nav`, here I've added the padding which seems to produce the expected layout:

<img width="1234" height="350" alt="image" src="https://github.com/user-attachments/assets/e23216cd-ad0b-4a71-99b4-8b86f3928c38" />

the `--topnav-offset` definition probably should be moved or inlined, but I'm not sure what the best options are for that so feel free to let me know or edit directly