### PR TITLE
Fix missing right border on last element in input groups

### DIFF
--- a/src/css/form.css
+++ b/src/css/form.css
@@ -202,7 +202,7 @@
       flex: 1;
       margin-block-start: 0;
      
-      &:not(:focus) {
+      &:not(:focus):not(:last-child) {
         border-inline-end-color: transparent;
       }
     }


### PR DESCRIPTION
This PR fixes the issue where fieldset.group elements appear visually "open" on the right side if they end with an input or are a single input group.

Fixes https://github.com/knadh/oat/issues/126