### PR TITLE
fix : correct typos in docs, templates, and source comments

### DIFF
--- a/docs/content/components/form.md
+++ b/docs/content/components/form.md
@@ -69,7 +69,7 @@ Form elements are styled automatically. Wrap inputs in `<label>` for proper asso
 
   <fieldset class="hstack">
     <legend>Preference</legend>
-    <label><input type="radio" name="pref">OptionA</label>
+    <label><input type="radio" name="pref">Option A</label>
     <label><input type="radio" name="pref">Option B</label>
     <label><input type="radio" name="pref">Option C</label>
   </fieldset>

--- a/docs/content/components/pagination.md
+++ b/docs/content/components/pagination.md
@@ -4,7 +4,7 @@ weight = 105
 description = "Pagination nav bars."
 +++
 
-Pagination does not use any special markup or classes and re-uses the exiting buttons `<menu>`.
+Pagination does not use any special markup or classes and re-uses the existing buttons `<menu>`.
 
 {% demo() %}
 ```html

--- a/docs/content/recipes.md
+++ b/docs/content/recipes.md
@@ -47,7 +47,7 @@ Group related form fields inside a card with standard field containers and actio
 <article class="card">
   <header>
     <h3>Profile</h3>
-    <p class="text-light">Update account infformation</p>
+    <p class="text-light">Update account information</p>
   </header>
 
   <div class="mt-4">

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -65,7 +65,7 @@
     <header>
       <h3>Easy customization</h3>
     </header>
-    <p>Easily customize the overall theme by overriding a handful of CSS variables. Automically picks up dark theme based on system preferences.</p>
+    <p>Easily customize the overall theme by overriding a handful of CSS variables. Automatically picks up dark theme based on system preferences.</p>
   </article>
 </section>
 

--- a/src/js/toast.js
+++ b/src/js/toast.js
@@ -80,7 +80,7 @@ function _remove(el, container) {
   el.addEventListener('transitionend', cleanup, { once: true });
 
   // Couldn't confirm what unit this actually returns across browsers, so
-  // assume that it could be ms or s. Also, setTimeou() is required because
+  // assume that it could be ms or s. Also, setTimeout() is required because
   // there's no guarantee that the `transitionend` event will always fire,
   // eg: clients that disable animations.
   const t = getComputedStyle(el).getPropertyValue('--transition').trim();


### PR DESCRIPTION
  - Fix "OptionA" → "Option A" (missing space) in docs/content/components/form.md                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      
  - Fix "exiting" → "existing" in docs/content/components/pagination.md                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  
  - Fix "infformation" → "information" in docs/content/recipes.md                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      
  - Fix "Automically" → "Automatically" in docs/templates/index.html                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
  - Fix "setTimeou()" → "setTimeout()" in src/js/toast.js                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
                                                          