### PR TITLE
docs: remove placeholder API doc link

### DIFF
--- a/docs/templates/demo.html
+++ b/docs/templates/demo.html
@@ -458,7 +458,7 @@
 
         <details name="faq">
           <summary>Can I integrate with third-party services?</summary>
-          <p>Yes! We offer integrations via our <strong>REST API</strong> and <em>webhooks</em>. See the <a href="#">API documentation</a> for details.</p>
+          <p>Yes! We offer integrations via our <strong>REST API</strong> and <em>webhooks</em>. See the API documentation for details.</p>
           <pre><code>curl -X POST https://api.example.com/webhooks \
   -H "Authorization: Bearer TOKEN"</code></pre>
         </details>


### PR DESCRIPTION
### Summary
Remove a placeholder `href="#"` link from the demo docs template.

### Details
In `docs/templates/demo.html`, the “API documentation” anchor used `href="#"`, which is a dead/placeholder link (it just jumps to the top of the page and provides no value). This PR replaces it with plain text to avoid misleading users and improve the demo UX.