### PR TITLE
fix: prevent .card from collapsing in height-constrained flex columns

### DIFF
--- a/src/css/card.css
+++ b/src/css/card.css
@@ -7,5 +7,6 @@
     box-shadow: var(--shadow-small);
     padding: var(--space-6);
     overflow: hidden;
+    min-height: min-content;
   }
 }


### PR DESCRIPTION
Fixes #147

## Problem

`.card` sets `overflow: hidden`, which per CSS spec causes `min-height: auto` to resolve to `0` for flex items. When a `.card` is a direct child of a height-constrained flex column (e.g. `main.vstack` inside `[data-sidebar-layout]`), `flex-shrink: 1` compresses the card to zero height.

## Fix

```css
.card {
  /* existing styles... */
  min-height: min-content;
}
```

One line. Ensures the card never shrinks below its content size while preserving `overflow: hidden` for border-radius clipping.

## What it doesn't change

- `overflow: hidden` stays — still needed for content containment and border-radius
- Cards outside flex contexts are completely unaffected
- No size increase to speak of (1 declaration)