### PR TITLE
feat: add breadcrumb & meter components, and expanded utilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,13 @@ CSS_FILES = src/css/00-base.css \
             src/css/form.css \
             src/css/table.css \
             src/css/progress.css \
+            src/css/meter.css \
             src/css/spinner.css \
             src/css/grid.css \
             src/css/card.css \
             src/css/alert.css \
             src/css/badge.css \
+            src/css/breadcrumb.css \
             src/css/accordion.css \
             src/css/tabs.css \
             src/css/dialog.css \

--- a/docs/content/components/breadcrumb.md
+++ b/docs/content/components/breadcrumb.md
@@ -4,19 +4,19 @@ weight = 45
 description = "Simple navigation hierarchy using nav and ordered lists"
 +++
 
-Use a semantic breadcrumb `<nav>` with an ordered list and `aria-current="page"` for the active item.
+Use a semantic breadcrumb `<nav>` with an ordered list and `aria-current="page"` for the active item. The component is styled automatically via `nav[aria-label="Breadcrumb"]` — no extra classes needed.
 
 {% demo() %}
 ```html
 <nav aria-label="Breadcrumb">
-  <ol class="unstyled hstack" style="font-size: var(--text-7)">
-    <li><a href="#breadcrumbs" class="unstyled">Home</a></li>
+  <ol>
+    <li><a href="#breadcrumbs">Home</a></li>
     <li aria-hidden="true">/</li>
-    <li><a href="#breadcrumbs" class="unstyled">Projects</a></li>
+    <li><a href="#breadcrumbs">Projects</a></li>
     <li aria-hidden="true">/</li>
-    <li><a href="#breadcrumbs" class="unstyled">Oat Docs</a></li>
+    <li><a href="#breadcrumbs">Oat Docs</a></li>
     <li aria-hidden="true">/</li>
-    <li><a href="#breadcrumbs" class="unstyled" aria-current="page"><strong>Breadcrumb</strong></a></li>
+    <li><a href="#breadcrumbs" aria-current="page">Breadcrumb</a></li>
   </ol>
 </nav>
 ```

--- a/docs/content/components/utilities.md
+++ b/docs/content/components/utilities.md
@@ -1,7 +1,15 @@
 +++
 title = "Utils and helpers"
 weight = 1000
-description = "Utility and helper classes."
+description = "Layout, text, and accessibility helpers."
 +++
 
 See [utilities.css](https://github.com/knadh/oat/blob/master/src/css/utilities.css) for commonly used utility and helper classes.
+
+| Class | Description |
+|---|---|
+| `.sr-only` | Visually hidden, accessible to screen readers |
+| `.truncate` | Text overflow ellipsis |
+| `.rounded` / `.rounded-full` | Border-radius shortcuts |
+| `.mx-auto` | Horizontal auto-centering |
+| `.no-print` | Hidden when printing |

--- a/src/css/breadcrumb.css
+++ b/src/css/breadcrumb.css
@@ -1,0 +1,33 @@
+@layer components {
+  nav[aria-label="Breadcrumb"] > ol,
+  nav[aria-label="breadcrumb"] > ol {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--text-7);
+    flex-wrap: wrap;
+
+    a {
+      color: var(--muted-foreground);
+      text-decoration: none;
+
+      &:hover {
+        color: var(--foreground);
+        text-decoration: underline;
+      }
+    }
+
+    li[aria-hidden="true"] {
+      color: var(--faint-foreground);
+      user-select: none;
+    }
+
+    [aria-current="page"] {
+      color: var(--foreground);
+      font-weight: var(--font-medium);
+      text-decoration: none;
+    }
+  }
+}

--- a/src/css/grid.css
+++ b/src/css/grid.css
@@ -53,6 +53,13 @@
     grid-column-end: -1;
   }
 
+  /* Responsive: tablet */
+  @media (max-width: 1024px) {
+    .row {
+      --grid-gap: 1.25rem;
+    }
+  }
+
   /* Responsive: stack on mobile */
   @media (max-width: 768px) {
     .row {

--- a/src/css/meter.css
+++ b/src/css/meter.css
@@ -1,0 +1,36 @@
+@layer base {
+  meter {
+    width: 100%;
+    height: var(--bar-height);
+    appearance: none;
+    border: none;
+    border-radius: var(--radius-full);
+    background: var(--muted);
+
+    &::-webkit-meter-bar {
+      background: var(--muted);
+      border-radius: var(--radius-full);
+      border: none;
+      height: var(--bar-height);
+    }
+
+    &::-webkit-meter-optimum-value {
+      background: var(--success);
+      border-radius: var(--radius-full);
+    }
+
+    &::-webkit-meter-suboptimum-value {
+      background: var(--warning);
+      border-radius: var(--radius-full);
+    }
+
+    &::-webkit-meter-even-less-good-value {
+      background: var(--danger);
+      border-radius: var(--radius-full);
+    }
+
+    &::-moz-meter-bar {
+      border-radius: var(--radius-full);
+    }
+  }
+}

--- a/src/css/utilities.css
+++ b/src/css/utilities.css
@@ -42,13 +42,49 @@
   .mb-2 { margin-block-end: var(--space-2); }
   .mb-4 { margin-block-end: var(--space-4); }
   .mb-6 { margin-block-end: var(--space-6); }
-  .p-4 { padding: var(--space-4); }
 
+  .p-0 { padding: 0; }
+  .p-1 { padding: var(--space-1); }
+  .p-2 { padding: var(--space-2); }
+  .p-3 { padding: var(--space-3); }
+  .p-4 { padding: var(--space-4); }
+  .p-6 { padding: var(--space-6); }
+
+  .mx-auto { margin-inline: auto; }
   .w-100 { width: 100%; }
+
+  .rounded { border-radius: var(--radius-medium); }
+  .rounded-full { border-radius: var(--radius-full); }
+
+  .truncate {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  /* Screen-reader only. */
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
 
   :is(ul, ol, a).unstyled {
     list-style: none;
     text-decoration: none;
     padding: 0;
+  }
+
+  /* Print overrides. */
+  @media print {
+    .no-print { display: none !important; }
+    body { background: white; color: black; }
+    a { color: inherit; }
   }
 }


### PR DESCRIPTION
- Adds a semantic breadcrumb component (no classes needed).
- Adds cross-browser styled <meter> element.
- Expands utilities (sr-only, truncate, rounded, print styles).
- Adds a tablet breakpoint to the grid (1024px).
- Tidies up docs and simplifies breadcrumb markup.