### PR TITLE
Tooltips: optional placement (top / bottom / left / right)

### DIFF
--- a/docs/content/components/tooltip.md
+++ b/docs/content/components/tooltip.md
@@ -4,7 +4,7 @@ weight = 155
 description = "Smooth tooltips using the native title attribute."
 +++
 
-Use the standard `title` attribute on any element to render a tooltip with smooth transition. [Replaced elements](https://developer.mozilla.org/en-US/docs/Glossary/Replaced_elements) like `<img>`, `<iframe>` etc. need to be wrapped in a parent with the `title` attribute.
+Use the standard `title` attribute on any element to render a tooltip with smooth transition. [Replaced elements](https://developer.mozilla.org/en-US/docs/Glossary/Replaced_elements) like `<img>`, `<iframe>` etc. need to be wrapped in a parent with the `title` attribute. Add `data-tooltip-placement` to position the tooltip. Default is `top`.
 
 {% demo() %}
 ```html
@@ -12,5 +12,10 @@ Use the standard `title` attribute on any element to render a tooltip with smoot
 <button title="Delete this item" data-variant="danger">Delete</button>
 <a href="#" title="View your profile">Profile</a>
 <span title="Images need a parent with title"><img src="https://oat.ink/logo.svg" height="32" /></span>
+
+<button title="On top">Top</button>
+<button title="Below" data-tooltip-placement="bottom">Bottom</button>
+<button title="On the left" data-tooltip-placement="left">Left</button>
+<button title="On the right" data-tooltip-placement="right">Right</button>
 ```
 {% end %}

--- a/src/css/tooltip.css
+++ b/src/css/tooltip.css
@@ -6,7 +6,6 @@
   [data-tooltip]::before,
   [data-tooltip]::after {
     position: absolute;
-    inset-inline-start: 50%;
     opacity: 0;
     visibility: hidden;
     transition: opacity var(--transition-fast), transform var(--transition-fast), visibility var(--transition-fast);
@@ -17,6 +16,7 @@
   /* Text */
   [data-tooltip]::after {
     content: attr(data-tooltip);
+    inset-inline-start: 50%;
     inset-block-end: calc(100% + 10px);
     transform: translateX(-50%) translateY(4px);
     padding: var(--space-2) var(--space-3);
@@ -28,20 +28,88 @@
     border-radius: var(--radius-medium);
   }
 
-  /* Arrow */
+  /* Arrow — top (default) */
   [data-tooltip]::before {
     content: '';
+    inset-inline-start: 50%;
     inset-block-end: calc(100% - 5px);
     transform: translateX(-50%) translateY(4px);
     border: 8px solid transparent;
     border-top-color: var(--foreground);
   }
 
+  [data-tooltip][data-tooltip-placement="bottom"]::after {
+    inset-block-start: calc(100% + 10px);
+    inset-block-end: auto;
+    transform: translateX(-50%) translateY(-4px);
+  }
+
+  [data-tooltip][data-tooltip-placement="bottom"]::before {
+    inset-block-start: calc(100% - 5px);
+    inset-block-end: auto;
+    transform: translateX(-50%) translateY(-4px);
+    border-top-color: transparent;
+    border-bottom-color: var(--foreground);
+  }
+
+  [data-tooltip][data-tooltip-placement="left"]::after {
+    inset-inline-start: auto;
+    inset-inline-end: calc(100% + 10px);
+    inset-block-start: 50%;
+    inset-block-end: auto;
+    transform: translateX(4px) translateY(-50%);
+  }
+
+  [data-tooltip][data-tooltip-placement="left"]::before {
+    inset-inline-start: auto;
+    inset-inline-end: calc(100% - 5px);
+    inset-block-start: 50%;
+    inset-block-end: auto;
+    transform: translateX(4px) translateY(-50%);
+    border-top-color: transparent;
+    border-bottom-color: transparent;
+    border-inline-end-color: transparent;
+    border-inline-start-color: var(--foreground);
+  }
+
+  [data-tooltip][data-tooltip-placement="right"]::after {
+    inset-inline-start: calc(100% + 10px);
+    inset-block-start: 50%;
+    inset-block-end: auto;
+    transform: translateX(-4px) translateY(-50%);
+  }
+
+  [data-tooltip][data-tooltip-placement="right"]::before {
+    inset-inline-start: calc(100% - 5px);
+    inset-block-start: 50%;
+    inset-block-end: auto;
+    transform: translateX(-4px) translateY(-50%);
+    border-top-color: transparent;
+    border-bottom-color: transparent;
+    border-inline-start-color: transparent;
+    border-inline-end-color: var(--foreground);
+  }
+
+  [data-tooltip][data-tooltip-placement="top"]::before {
+    border-top-color: var(--foreground);
+    border-bottom-color: transparent;
+    border-inline-start-color: transparent;
+    border-inline-end-color: transparent;
+  }
+
+  /* Top + bottom share the same visible transform */
   [data-tooltip]:is(:hover, :focus-visible)::before,
   [data-tooltip]:is(:hover, :focus-visible)::after {
     opacity: 1;
     visibility: visible;
     transition-delay: 700ms;
     transform: translateX(-50%) translateY(0);
+  }
+
+  [data-tooltip][data-tooltip-placement="left"]:is(:hover, :focus-visible)::before,
+  [data-tooltip][data-tooltip-placement="left"]:is(:hover, :focus-visible)::after,
+  [data-tooltip][data-tooltip-placement="right"]:is(:hover, :focus-visible)::before,
+  [data-tooltip][data-tooltip-placement="right"]:is(:hover, :focus-visible)::after {
+    transform: translateX(0) translateY(-50%);
   }
 }

--- a/src/css/tooltip.css
+++ b/src/css/tooltip.css
@@ -6,6 +6,7 @@
   [data-tooltip]::before,
   [data-tooltip]::after {
     position: absolute;
+    inset-inline-start: 50%;
     opacity: 0;
     visibility: hidden;
     transition: opacity var(--transition-fast), transform var(--transition-fast), visibility var(--transition-fast);
@@ -16,7 +17,6 @@
   /* Text */
   [data-tooltip]::after {
     content: attr(data-tooltip);
-    inset-inline-start: 50%;
     inset-block-end: calc(100% + 10px);
     transform: translateX(-50%) translateY(4px);
     padding: var(--space-2) var(--space-3);
@@ -28,76 +28,66 @@
     border-radius: var(--radius-medium);
   }
 
-  /* Arrow — top (default) */
+  /* Arrow (default: top) */
   [data-tooltip]::before {
     content: '';
-    inset-inline-start: 50%;
     inset-block-end: calc(100% - 5px);
     transform: translateX(-50%) translateY(4px);
     border: 8px solid transparent;
     border-top-color: var(--foreground);
   }
 
+  /* Bottom */
   [data-tooltip][data-tooltip-placement="bottom"]::after {
     inset-block-start: calc(100% + 10px);
     inset-block-end: auto;
     transform: translateX(-50%) translateY(-4px);
   }
-
   [data-tooltip][data-tooltip-placement="bottom"]::before {
     inset-block-start: calc(100% - 5px);
     inset-block-end: auto;
     transform: translateX(-50%) translateY(-4px);
-    border-top-color: transparent;
+    border-color: transparent;
     border-bottom-color: var(--foreground);
   }
 
-  [data-tooltip][data-tooltip-placement="left"]::after {
-    inset-inline-start: auto;
-    inset-inline-end: calc(100% + 10px);
+  /* Left + Right */
+  [data-tooltip]:is([data-tooltip-placement="left"], [data-tooltip-placement="right"])::before,
+  [data-tooltip]:is([data-tooltip-placement="left"], [data-tooltip-placement="right"])::after {
     inset-block-start: 50%;
     inset-block-end: auto;
-    transform: translateX(4px) translateY(-50%);
+  }
+  [data-tooltip]:is([data-tooltip-placement="left"], [data-tooltip-placement="right"])::before {
+    border-color: transparent;
   }
 
-  [data-tooltip][data-tooltip-placement="left"]::before {
+  /* Left */
+  [data-tooltip][data-tooltip-placement="left"]::before,
+  [data-tooltip][data-tooltip-placement="left"]::after {
     inset-inline-start: auto;
-    inset-inline-end: calc(100% - 5px);
-    inset-block-start: 50%;
-    inset-block-end: auto;
     transform: translateX(4px) translateY(-50%);
-    border-top-color: transparent;
-    border-bottom-color: transparent;
-    border-inline-end-color: transparent;
+  }
+  [data-tooltip][data-tooltip-placement="left"]::after {
+    inset-inline-end: calc(100% + 10px);
+  }
+  [data-tooltip][data-tooltip-placement="left"]::before {
+    inset-inline-end: calc(100% - 5px);
     border-inline-start-color: var(--foreground);
   }
 
+  /* Right */
+  [data-tooltip][data-tooltip-placement="right"]::before,
   [data-tooltip][data-tooltip-placement="right"]::after {
-    inset-inline-start: calc(100% + 10px);
-    inset-block-start: 50%;
-    inset-block-end: auto;
     transform: translateX(-4px) translateY(-50%);
   }
-
+  [data-tooltip][data-tooltip-placement="right"]::after {
+    inset-inline-start: calc(100% + 10px);
+  }
   [data-tooltip][data-tooltip-placement="right"]::before {
     inset-inline-start: calc(100% - 5px);
-    inset-block-start: 50%;
-    inset-block-end: auto;
-    transform: translateX(-4px) translateY(-50%);
-    border-top-color: transparent;
-    border-bottom-color: transparent;
-    border-inline-start-color: transparent;
     border-inline-end-color: var(--foreground);
   }
 
-  [data-tooltip][data-tooltip-placement="top"]::before {
-    border-top-color: var(--foreground);
-    border-bottom-color: transparent;
-    border-inline-start-color: transparent;
-    border-inline-end-color: transparent;
-  }
-
-  /* Top + bottom share the same visible transform */
   [data-tooltip]:is(:hover, :focus-visible)::before,
   [data-tooltip]:is(:hover, :focus-visible)::after {
     opacity: 1;
@@ -105,11 +95,8 @@
     transition-delay: 700ms;
     transform: translateX(-50%) translateY(0);
   }
-
-  [data-tooltip][data-tooltip-placement="left"]:is(:hover, :focus-visible)::before,
-  [data-tooltip][data-tooltip-placement="left"]:is(:hover, :focus-visible)::after,
-  [data-tooltip][data-tooltip-placement="right"]:is(:hover, :focus-visible)::before,
-  [data-tooltip][data-tooltip-placement="right"]:is(:hover, :focus-visible)::after {
+  [data-tooltip]:is([data-tooltip-placement="left"], [data-tooltip-placement="right"]):is(:hover, :focus-visible)::before,
+  [data-tooltip]:is([data-tooltip-placement="left"], [data-tooltip-placement="right"]):is(:hover, :focus-visible)::after {
     transform: translateX(0) translateY(-50%);
   }
 }

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -1,6 +1,8 @@
 /**
  * oat - Tooltip Enhancement
  * Converts title attributes to data-tooltip for custom styling.
+ * Optional data-tooltip-placement (top | bottom | left | right) is left on the
+ * element for CSS; default is top when omitted or invalid.
  * Progressive enhancement: native title works without JS.
  */
 

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -1,8 +1,6 @@
 /**
  * oat - Tooltip Enhancement
  * Converts title attributes to data-tooltip for custom styling.
- * Optional data-tooltip-placement (top | bottom | left | right) is left on the
- * element for CSS; default is top when omitted or invalid.
  * Progressive enhancement: native title works without JS.
  */
 


### PR DESCRIPTION
Tooltips used to render only above the trigger. This change adds data-tooltip-placement so they can open in four directions, while keeping the same progressive enhancement model (title still works without JS).

## What changed
src/css/tooltip.css — Placement variants for data-tooltip-placement="bottom", left, and right, with top remaining the default when the attribute is missing, empty, or invalid. Styling stays in the same flat @layer components + full-selector style as before. Left/right use logical properties so they follow LTR/RTL.
src/js/tooltip.js — Comments clarify that data-tooltip-placement is not removed when title is copied to data-tooltip (behaviour unchanged; markup continues to drive placement).

## How to use

```
<button title="Above" data-tooltip-placement="top">Top</button>
<button title="Below" data-tooltip-placement="bottom">Bottom</button>
<button data-tooltip="Left" data-tooltip-placement="left" aria-label="Left">Left</button>
<button data-tooltip="Right" data-tooltip-placement="right" aria-label="Right">Right</button>
```
![Recording 2026-04-04 155146](https://github.com/user-attachments/assets/7e121455-63b5-422f-8dd3-6a6308b44cb6)
