### PR TITLE
docs(usage): align basic example with published minified asset names

### DIFF
--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -59,8 +59,8 @@ Oat styles semantic HTML elements by default. No classes needed for basic stylin
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>My App</title>
-  <link rel="stylesheet" href="oat.css">
-  <script src="oat.js" defer></script>
+  <link rel="stylesheet" href="oat.min.css">
+  <script src="oat.min.js" defer></script>
 </head>
 <body>
   <h1>Hello World</h1>


### PR DESCRIPTION
This updates the Basic usage snippet in docs/content/usage.md to use oat.min.css and oat.min.js instead of oat.css and oat.js so that copy-paste instructions are consistent across the usage page 