### PR TITLE
feat(dropdown): add opt-in `close-on-click` attribute

### DIFF
--- a/docs/content/components/dropdown.md
+++ b/docs/content/components/dropdown.md
@@ -9,6 +9,10 @@ webcomponent = true
 
 Wrap in `<ot-dropdown>`. Use `popovertarget` on the trigger and `popover` on the target. If a dropdown `<menu>`, items use `role="menuitem"`.
 
+#### Attributes
+
+- `close-on-click` — close the popover when a `role="menuitem"` is clicked. By default, the popover stays open on item click and only closes on outside click or another toggle.
+
 {% demo() %}
 ```html
 <ot-dropdown>
@@ -17,6 +21,28 @@ Wrap in `<ot-dropdown>`. Use `popovertarget` on the trigger and `popover` on the
     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6" /></svg>
   </button>
   <menu popover id="demo-menu">
+    <button role="menuitem">Profile</button>
+    <button role="menuitem">Settings</button>
+    <button role="menuitem">Help</button>
+    <hr>
+    <button role="menuitem">Logout</button>
+  </menu>
+</ot-dropdown>
+```
+{% end %}
+
+### Close on click
+
+Add the `close-on-click` attribute to dismiss the popover as soon as a menu item is activated.
+
+{% demo() %}
+```html
+<ot-dropdown close-on-click>
+  <button popovertarget="demo-menu-coc" class="outline">
+    Options
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6" /></svg>
+  </button>
+  <menu popover id="demo-menu-coc">
     <button role="menuitem">Profile</button>
     <button role="menuitem">Settings</button>
     <button role="menuitem">Help</button>

--- a/src/js/dropdown.js
+++ b/src/js/dropdown.js
@@ -28,6 +28,7 @@ class OtDropdown extends OtBase {
 
     this.#menu.addEventListener('toggle', this);
     this.#menu.addEventListener('keydown', this);
+    this.#menu.addEventListener('click', this);
 
     this.#position = () => {
       // Position has to be calculated and applied manually because
@@ -63,6 +64,13 @@ class OtDropdown extends OtBase {
     const idx = this.#items.indexOf(e.target);
     const next = this.keyNav(e, idx, this.#items.length, 'ArrowUp', 'ArrowDown', true);
     if (next >= 0) this.#items[next].focus();
+  }
+
+  onclick(e) {
+    if (!this.hasAttribute('close-on-click')) return;
+    if (!e.target.closest('[role="menuitem"]')) return;
+
+    this.#menu.hidePopover();
   }
 
   cleanup() {


### PR DESCRIPTION
## Summary

Adds an opt-in `close-on-click` attribute on `<ot-dropdown>` that automatically dismisses the popover as soon as a `role="menuitem"` is clicked.

## Why

Previously, clicking a menu item inside a `<ot-dropdown>` popover did **not** close the popover — it only closed on an outside click or another toggle. For in-page actions (e.g. toggling a theme, muting a channel, switching a view) that don't trigger a navigation or page refresh, the dropdown stayed open and the user had to dismiss it manually. That made the menu feel sticky and broke the expected menu UX.

With `close-on-click`, the popover closes immediately on item click, giving the expected "menu item activates and the menu disappears" behavior — without forcing it on use cases that *do* rely on the popover staying open (e.g. forms, multi-step confirmations).

## Usage

```html
<ot-dropdown close-on-click>
  <button popovertarget="my-menu" class="outline">Options</button>
  <menu popover id="my-menu">
    <button role="menuitem">Profile</button>
    <button role="menuitem">Settings</button>
    <button role="menuitem">Help</button>
  </menu>
</ot-dropdown>
```

The default behavior is unchanged: the attribute is opt-in, and popovers without it still stay open on item click.