### PR TITLE
Fix broken grid offset formula

### DIFF
--- a/src/css/grid.css
+++ b/src/css/grid.css
@@ -21,7 +21,7 @@
   }
 
   /* Column spans */
-  .col, [class*="col-"] { grid-column-end: span calc(var(--span, var(--grid-cols)) + var(--offset, 0)); }
+  .col, [class*="col-"] { grid-column-end: span var(--span, var(--grid-cols)); }
 
   .col-1  { --span: 1; }
   .col-2  { --span: 2; }
@@ -45,7 +45,7 @@
   .offset-6  { --offset: 6; }
 
   [class*="offset-"] {
-    margin-inline-start: calc(var(--offset) * (100% + var(--grid-gap)) / (var(--span) + var(--offset)));
+    margin-inline-start: calc(var(--offset) * (100% + var(--grid-gap)) / var(--grid-cols));
   }
 
   .col-end {


### PR DESCRIPTION
The offset margin formula in grid.css had two bugs that produced incorrect column offsets.

Bug 1: Wrong denominator

The formula was dividing by (var(--span) + var(--offset)) instead of var(--grid-cols). This meant the offset depended on the element's own width, which is semantically wrong. Two columns of offset should always equal two columns of displacement, regardless of the element's span.

For a 1200px container with 12 columns and 24px gap, col-4.offset-2 produced a 408px offset instead of the correct 204px. The error factor equals grid-cols / (span + offset). For col-3.offset-1 the offset was 306px instead of 102px.

Bug 2: Offset added to column span

The column span rule was span calc(var(--span) + var(--offset)), which made offset elements wider by the offset amount. A col-4.offset-2 element spanned 6 columns instead of 4. Offset should shift the start position, not increase the width.

Fix applied in src/css/grid.css:

- Line 24: Removed + var(--offset, 0) from the span calculation.
- Line 48: Changed denominator from (var(--span) + var(--offset)) to var(--grid-cols).

Verification (1200px container, 12 cols, 24px gap):

- col-4.offset-2: was 408px, now 204px (expected 204px)
- col-3.offset-1: was 306px, now 102px (expected 102px)
- col-6: unchanged (0px)

The responsive mobile breakpoint already resets offset to 0 and span to 4, so no changes needed there.