### PR TITLE
Fix documentation errors: wrong theme colors, missing variables, invalid HTML

### DIFF
--- a/docs/content/components/button.md
+++ b/docs/content/components/button.md
@@ -4,7 +4,7 @@ weight = 50
 description = "Button variants and sizes"
 +++
 
-The `<button>` element is styled by default. Use `data-variant="primary|secondary|danger"` for semantic variants and classes for visual styles.
+The `<button>` element is styled by default. Use `data-variant="secondary|danger"` for semantic variants and classes for visual styles.
 
 {% demo() %}
 ```html

--- a/docs/content/components/sidebar.md
+++ b/docs/content/components/sidebar.md
@@ -30,7 +30,7 @@ description = "Responsive admin dashboard layout with sticky sidebar, optional t
       </ul>
     </nav>
     <footer>
-      <button class="outline" class="sm" style="width: 100%;">Logout</button>
+      <button class="outline small" style="width: 100%;">Logout</button>
     </footer>
   </aside>
   <main>
@@ -53,7 +53,7 @@ Set `data-sidebar-layout="always"` to keep the toggle visible and make it collap
 
 ### With top sticky nav
 
-Add `data-topnav` to a header element for a full-width top navigation bar. The sidebar will adjust to sit below it. Inspect the HTML source of this website for a live example.
+Add `data-topnav` to a nav element for a full-width top navigation bar. The sidebar will adjust to sit below it. Inspect the HTML source of this website for a live example.
 
 ```html
 <body data-sidebar-layout>
@@ -80,7 +80,7 @@ Add `data-topnav` to a header element for a full-width top navigation bar. The s
 | ------------------------------ | ---------- | ------------------------------------------------------------------------------ |
 | `data-sidebar-layout`          | Container  | Grid layout wrapper (sidebar + main), typically `<body>`                       |
 | `data-sidebar-layout="always"` | Container  | Always-collapsible sidebar (toggle visible and functional on all screen sizes) |
-| `data-topnav`                  | `<header>` | Full-width top nav (optional, spans full width)                                |
+| `data-topnav`                  | `<nav>`    | Full-width top nav (optional, spans full width)                                |
 | `data-sidebar`                 | `<aside>`  | Sticky sidebar element                                                         |
 | `data-sidebar-toggle`          | `<button>` | Toggles sidebar (mobile) and collapse (always mode)                            |
 | `data-sidebar-open`            | Layout     | Applied to layout when sidebar is open                                         |

--- a/docs/content/components/toast.md
+++ b/docs/content/components/toast.md
@@ -30,7 +30,7 @@ ot.toast('Bottom right', '',{ placement: 'bottom-right' })
 
 | Option      | Default       | Description                          |
 | ----------- | ------------- | ------------------------------------ |
-| `variant`   | `''`          | `'success'`, `'danger'`, `'warning'` |
+| `variant`   | `'info'`      | `'success'`, `'danger'`, `'warning'` |
 | `placement` | `'top-right'` | Position on screen                   |
 | `duration`  | `4000`        | Auto-dismiss in ms (0 = persistent)  |
 

--- a/docs/content/customizing.md
+++ b/docs/content/customizing.md
@@ -37,7 +37,7 @@ The following color variables from theme.css control the theme (colour profile).
   --card-foreground: rgb(9 9 11);
 
   /* Primary buttons and links */
-  --primary: rgb(24 24 27);
+  --primary: rgb(87 71 71);
 
   /* Text color on primary buttons */
   --primary-foreground: rgb(250 250 250);
@@ -46,7 +46,7 @@ The following color variables from theme.css control the theme (colour profile).
   --secondary: rgb(244 244 245);
 
   /* Text colour on secondary buttons */
-  --secondary-foreground: rgb(24 24 27);
+  --secondary-foreground: rgb(87 71 71);
 
   /* Muted (lighter) background */
   --muted: rgb(244 244 245);
@@ -63,23 +63,20 @@ The following color variables from theme.css control the theme (colour profile).
   /* Accent background */
   --accent: rgb(244 244 245);
 
-  /* Accent text color */
-  --accent-foreground: rgb(24 24 27);
-
   /* Error/danger color */
-  --danger: rgb(223 81 76);
+  --danger: rgb(211 47 47);
 
   /* Text color on danger background */
   --danger-foreground: rgb(250 250 250);
 
   /* Success color */
-  --success: rgb(76 175 80);
+  --success: rgb(0 128 50);
 
   /* Text colour on success background */
   --success-foreground: rgb(250 250 250);
 
   /* Warning color */
-  --warning: rgb(255 140 0);
+  --warning: rgb(166 91 0);
 
   /* Text colour on warning background */
   --warning-foreground: rgb(9 9 11);
@@ -91,7 +88,7 @@ The following color variables from theme.css control the theme (colour profile).
   --input: rgb(212 212 216);
 
   /* Focus ring color */
-  --ring: rgb(24 24 27);
+  --ring: rgb(87 71 71);
 }
 ```
 
@@ -113,12 +110,13 @@ After these, include CSS and JS files the respective components.
 --muted: #f4f4f5;
 --muted-foreground: #71717a;
 --faint: #fafafa;
+--faint-foreground: #a1a1aa;
 --accent: #f4f4f5;
---danger: #df514c;
+--danger: #d32f2f;
 --danger-foreground: #fafafa;
---success: #4caf50;
+--success: #008032;
 --success-foreground: #fafafa;
---warning: #ff8c00;
+--warning: #a65b00;
 --warning-foreground: #09090b;
 --border: #d4d4d8;
 --input: #d4d4d8;
@@ -129,4 +127,4 @@ After these, include CSS and JS files the respective components.
 
 ## Dark mode
 
-Adding `data-theme="dark"` to `<body>` applies the dark theme. Customize the dark theme by redefining the aforementioned theme variables and scoping them inside `[data-theme="dark"] { ... }`
+Dark mode is applied automatically via `light-dark()` and `color-scheme: light dark`, following the OS system preference. To customize the dark theme, redefine the theme variables scoped inside a `[data-theme="dark"]` selector in your own CSS, and set `data-theme="dark"` on `<body>` to activate it manually.


### PR DESCRIPTION
customizing.md:

- Fix 3 wrong color values in Default Oat brown section: danger (#df514c -> #d32f2f), success (#4caf50 -> #008032), warning (#ff8c00 -> #a65b00)
- Add missing --faint-foreground variable to Default Oat brown section
- Fix wrong color values in Theming reference section: primary, secondary-foreground, danger, success, warning, ring
- Remove non-existent --accent-foreground variable from Theming reference
- Fix dark mode docs: data-theme is not built-in, dark mode uses light-dark() + color-scheme automatically following OS preference

sidebar.md:

- Fix prose line 56: data-topnav goes on nav element, not header
- Fix structure table: data-topnav element is nav, not header
- Fix invalid HTML at line 33: removed duplicate class attribute, changed class=sm to class=small

button.md:

- Remove non-existent data-variant=primary from variant list. Default button without variant is already primary.

toast.md:

- Fix default variant in options table: empty string changed to 'info' (matches toast.js line 94)