### PR TITLE
Fix mobile sidebar overflow

### DIFF
--- a/src/css/sidebar.css
+++ b/src/css/sidebar.css
@@ -165,7 +165,7 @@
       > aside[data-sidebar] {
         grid-column: 1;
         z-index: 2;
-        width: var(--sidebar-width);
+        width: min(var(--sidebar-width), 100vw);
         transform: translateX(-100%);
         transition: transform var(--transition);
         box-shadow: var(--shadow-large);


### PR DESCRIPTION
## Summary

- Cause: On mobile, a configured sidebar wider than the viewport expanded the grid even while translated off canvas.
- Fix: Cap the mobile sidebar width to the viewport with `min(var(--sidebar-width), 100vw)`.
- Pattern alignment: Reuses the existing `width: min(...)` responsive sizing pattern from the dialog component and keeps the change to one CSS line.

Fixes #174

## Verification

- `make clean dist`
- Verified in Chrome responsive mode at 400px with `--sidebar-width: 50rem`; both closed and open states remained 400px wide with no horizontal overflow.
