### PR TITLE
Fix table tooltip clipping

### DIFF
--- a/src/css/table.css
+++ b/src/css/table.css
@@ -4,6 +4,10 @@
     min-width: 320px;
     width: 100%;
     overflow-x: auto;
+
+    &:has([data-tooltip]:is(:hover, :focus-visible)) {
+      overflow: visible;
+    }
   }
 
   table {


### PR DESCRIPTION
## Summary

### Cause

The `.table` wrapper uses `overflow-x: auto` to preserve horizontal scrolling. CSS computes the other overflow axis to `auto` as well, so the wrapper creates a vertical clipping boundary. Tooltips are absolutely positioned outside their trigger, which means first-row top tooltips and last-row bottom tooltips are clipped even though the tooltip itself has a high `z-index`.

### Fix

Temporarily switch the table wrapper to `overflow: visible` while a descendant tooltip is hovered or keyboard-focused. When the tooltip is inactive, the wrapper keeps its existing `overflow-x: auto` behavior and horizontal scrolling remains unchanged.

### Pattern alignment

The fix stays in `table.css`, next to the rule that owns the clipping behavior. It uses the same nested CSS and `:is(:hover, :focus-visible)` state pattern already used by the tooltip component, without changing tooltip markup, JavaScript, placement logic, or the table structure. The minified gzip increase is 18 bytes.

Fixes #161

## Verification

- Ran `make clean dist` successfully.
- Reproduced the clipping on the current `master` branch with a top tooltip in the first table row.
- Verified with Computer Use in Safari using real keyboard focus.
- Confirmed first-row top and last-row bottom tooltips render fully outside the table boundary.
- Confirmed the wrapper reports `overflow: visible` only while a tooltip is active and returns to `overflow: auto` otherwise.

### Screenshots

First-row top tooltip:

![First-row top tooltip rendering outside the table boundary](https://raw.githubusercontent.com/UjjwalGupta49/oat/pr-assets/issue-161/top-tooltip.jpeg)

Last-row bottom tooltip:

![Last-row bottom tooltip rendering outside the table boundary](https://raw.githubusercontent.com/UjjwalGupta49/oat/pr-assets/issue-161/bottom-tooltip.jpeg)
