### PR TITLE
Allow labels as children of fieldset.group

### DIFF
--- a/docs/content/components/form.md
+++ b/docs/content/components/form.md
@@ -115,6 +115,13 @@ Use `.group` on a `<fieldset>` to combine inputs with buttons or labels.
   <input type="text" placeholder="Search" />
   <button>Go</button>
 </fieldset>
+
+<fieldset class="group">
+    <input type="text" placeholder="2" />
+    <label>hour(s)</label>
+    <input type="text" placeholder="30" />
+    <label>minute(s)</label>
+</fieldset>
 ```
 {% end %}
 

--- a/src/css/form.css
+++ b/src/css/form.css
@@ -219,7 +219,7 @@
       }
     }
 
-    & > legend {
+    & > legend, & > label {
       float: inline-start;
       display: inline-flex;
       align-items: center;

--- a/src/css/form.css
+++ b/src/css/form.css
@@ -229,8 +229,18 @@
       color: var(--muted-foreground);
       background-color: var(--muted);
       border: 1px solid var(--input);
-      border-inline-end: none;
-      border-radius: var(--radius-medium) 0 0 var(--radius-medium);
+
+      &:not(:last-child) {
+        border-inline-end: 0;
+      }
+  
+      &:first-child {
+        border-radius: var(--radius-medium) 0 0 var(--radius-medium);
+      }
+  
+      &:last-child {
+        border-radius: 0 var(--radius-medium) var(--radius-medium) 0;
+      }
     }
   }
 


### PR DESCRIPTION
Previously, only a `<legend>` element could be used as a label within a `<fieldset class="group">`.
With this PR, `<label>` elements may be added anywhere within the `<fieldset>` element and be styled with the correct border radii.

**Before (7,033 KB):**
<img width="595" height="250" alt="grafik" src="https://github.com/user-attachments/assets/a2429e74-b0a9-4790-91fe-eee18fa91a7f" />
(This example used the `<legend>` element at various positions, which is not permitted by HTML specification)

**After (7,042 KB):**
<img width="586" height="245" alt="grafik" src="https://github.com/user-attachments/assets/a5873646-6476-458d-9235-6ac0258990e2" />
(This now shows `<label>` elements that can be positioned anywhere inside the `<fieldset>` element)

**I also added an appropriate example to the docs:**
<img width="897" height="362" alt="grafik" src="https://github.com/user-attachments/assets/522d8c84-9222-4277-b84d-a56de3618044" />