### PR TITLE
Add recipes: download, copy-to-clipboard, loading, confirm-delete buttons

### DIFF
--- a/docs/content/recipes.md
+++ b/docs/content/recipes.md
@@ -168,3 +168,86 @@ Compose dashboard metrics with `grid`, `card`, `badge`, and `progress`/`meter`.
 </div>
 ```
 {% end %}
+
+## Download button
+
+Add the `download` attribute to a hyperlink to trigger a file download. Style it with `.button` and any button variant, same as any other link.
+
+{% demo() %}
+```html
+<a href="/oat.min.css" download class="button">
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 4v12m0 0-4-4m4 4 4-4" /><path d="M4 16v4h16v-4" /></svg>
+  Download CSS
+</a>
+
+<a href="/oat.min.js" download class="outline">
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 4v12m0 0-4-4m4 4 4-4" /><path d="M4 16v4h16v-4" /></svg>
+  Download JS
+</a>
+```
+{% end %}
+
+## Copy-to-clipboard button
+
+An icon button that copies text and briefly swaps to a checkmark icon to confirm the action, using the Clipboard API and the native `hidden` attribute. No new component or CSS state needed.
+
+{% demo() %}
+```html
+<button class="icon outline" aria-label="Copy install command" onclick="navigator.clipboard.writeText('npm install oat-ui'); this.querySelector('[data-icon=copy]').hidden = true; this.querySelector('[data-icon=check]').hidden = false; setTimeout(() => { this.querySelector('[data-icon=copy]').hidden = false; this.querySelector('[data-icon=check]').hidden = true }, 1500)">
+  <svg data-icon="copy" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" /></svg>
+  <svg data-icon="check" hidden width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12" /></svg>
+</button>
+```
+{% end %}
+
+For anything beyond a one-liner, wire the same swap up as a real event listener instead of an inline attribute:
+
+```javascript
+button.addEventListener('click', async () => {
+  await navigator.clipboard.writeText('npm install oat-ui');
+  button.querySelector('[data-icon=copy]').hidden = true;
+  button.querySelector('[data-icon=check]').hidden = false;
+  setTimeout(() => {
+    button.querySelector('[data-icon=copy]').hidden = false;
+    button.querySelector('[data-icon=check]').hidden = true;
+  }, 1500);
+});
+```
+
+## Loading button
+
+Toggle `aria-busy="true"` and `disabled` on submit to show the built-in spinner while an action is pending. No new markup or JS beyond the one-line handler.
+
+{% demo() %}
+```html
+<form onsubmit="event.preventDefault(); const b = this.querySelector('button'); b.setAttribute('aria-busy', 'true'); b.disabled = true">
+  <button type="submit" data-spinner="small">Save</button>
+</form>
+```
+{% end %}
+
+## Confirm-before-delete dialog
+
+Reuse the native `<dialog>` `commandfor`/`command` pattern to confirm a destructive action before it runs. Zero JavaScript.
+
+{% demo() %}
+```html
+<button data-variant="danger" class="outline" commandfor="confirm-delete" command="show-modal">
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" /><line x1="10" y1="11" x2="10" y2="17" /><line x1="14" y1="11" x2="14" y2="17" /></svg>
+  Delete
+</button>
+
+<dialog id="confirm-delete" closedby="any">
+  <form method="dialog">
+    <header>
+      <h3>Delete item</h3>
+      <p>This action cannot be undone.</p>
+    </header>
+    <footer>
+      <button type="button" commandfor="confirm-delete" command="close" class="outline">Cancel</button>
+      <button value="confirm" data-variant="danger">Delete</button>
+    </footer>
+  </form>
+</dialog>
+```
+{% end %}


### PR DESCRIPTION
Closes #181
Four small additions to recipes.md — no new CSS/JS, just existing
components and browser APIs already used elsewhere in the docs.